### PR TITLE
Remove the `immediate` keyword from `BasePublisherWithReplyQueue.publish`

### DIFF
--- a/kiwipy/rmq/messages.py
+++ b/kiwipy/rmq/messages.py
@@ -194,18 +194,17 @@ class BasePublisherWithReplyQueue(object):
         return message.future
 
     @gen.coroutine
-    def publish(self, message, routing_key, mandatory=True, immediate=False):
+    def publish(self, message, routing_key, mandatory=True):
         """
         Send a fire-and-forget message i.e. no response expected.
 
         :param message: The message to send
         :param routing_key: The routing key
         :param mandatory: If the message cannot be routed this will raise an UnroutableException
-        :param immediate: Return the message if it cannot be queued immediately
         :return:
         """
         result = yield self._exchange.publish(
-            message, routing_key=routing_key, mandatory=mandatory, immediate=immediate)
+            message, routing_key=routing_key, mandatory=mandatory)
         raise gen.Return(result)
 
     @gen.coroutine

--- a/setup.py
+++ b/setup.py
@@ -47,13 +47,13 @@ setup(
     ],
     extras_require={
         'rmq': [
-            'pika>="1.0.0b1"', 'topika>="0.1.2"', 'tornado>=4; python_version<"3"', 'tornado<5; python_version>="3"',
+            'pika>=1.0.0b2', 'topika~=0.2.0', 'tornado>=4; python_version<"3"', 'tornado<5; python_version>="3"',
             'pyyaml'
         ],
         'dev': [
             'pip',
             'pre-commit',
-            'pytest',
+            'pytest>=4',
             'pytest-cov',
             'ipython',
             'twine',


### PR DESCRIPTION
Fixes #20 
Currently blocked because the required changes in `topika` have not yet been released

This was deprecated in `pika==1.0.0` and in `topika` by extension