### PR TITLE
tornado_to_kiwi_future thread safe fix

### DIFF
--- a/kiwipy/rmq/communicator.py
+++ b/kiwipy/rmq/communicator.py
@@ -570,6 +570,7 @@ class RmqThreadCommunicator(kiwipy.Communicator):
 
         # The stop will end up setting self._communicator_thread to None
         self._loop.add_callback(stop_loop)
+        ioloop.IOLoop.clear_current()
         comm_thread.join()
         stop_future.result()
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='communication messaging rpc broadcast',
     install_requires=[
@@ -42,8 +43,9 @@ setup(
         'rmq': [
             'pika>=1.0.0b2',
             'topika>=0.2.0, <0.3.0',
-            'tornado>=4; python_version<"3"',
-            'tornado<5; python_version>="3"',
+            # 'tornado>=4; python_version<"3"',
+            # 'tornado<5; python_version>="3"',
+            'tornado>=4,<6.0',
             'pyyaml'
         ],
         'dev': [


### PR DESCRIPTION
In function `tornado_to_kiwi_future`, state of `self.loop()` and `self.loop().current` is different.

Add `ioloop.IOLoop.clear_current()` in `stop()` fix the Thread test.

Is this the right way to fix the [bug #9](https://github.com/aiidateam/kiwipy/issues/9#issue-365066244)?