### PR TITLE
Enable testing for python 3.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: python
 cache: pip
 
-services:
-  - rabbitmq
+
+before_install:
+  - sudo apt-get install rabbitmq-server
+addons:
+  apt:
+    update: true
 
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 
 matrix:
-  allow_failures:
-    - python: 3.7
   include:
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='communication messaging rpc broadcast',
     install_requires=[


### PR DESCRIPTION
Fixes #25 

The only problem is that python 3.7 still requires xenial on Travis
which doesn't come with `rabbitmq` as a service, so we have to install
manually through `sudo apt`.