### PR TITLE
Update `pyyaml` to prevent arbitrary code execution

### DIFF
--- a/kiwipy/rmq/defaults.py
+++ b/kiwipy/rmq/defaults.py
@@ -18,4 +18,4 @@ TASK_PREFETCH_SIZE = 0
 TASK_PREFETCH_COUNT = 0
 
 ENCODER = partial(yaml.dump, encoding='utf-8')
-DECODER = partial(yaml.load, Loader=yaml.Loader)
+DECODER = partial(yaml.load, Loader=yaml.FullLoader)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name="kiwipy",
       extras_require={
           'rmq': [
               'pika>=1.0.0', 'topika>=0.2.0, <0.3.0', 'tornado<6; python_version<"3"', 'tornado<5; python_version>="3"',
-              'pyyaml'
+              'pyyaml~=5.1'
           ],
           'dev': [
               'pip',


### PR DESCRIPTION
Fixes #36 

Before `pyyaml==5.1` the `yaml.load` function was vulnerable to
arbitrary code execution, because it loaded the full set of YAML. There
was an alternative `safe_load` but this was not the default and could
only load a sub set of the markup language. The new version of pyyaml
deprecates the old vulnerable code and provides the `FullLoader` that
can load the full set without being vulnerable. The `safe_load` is
syntactic sugar for `load` with `Loader=FullLoader`.