### PR TITLE
Bugfix task subscribers

### DIFF
--- a/kiwipy/communications.py
+++ b/kiwipy/communications.py
@@ -51,10 +51,14 @@ class Communicator:
 
     @abc.abstractmethod
     def remove_task_subscriber(self, identifier):
-        """Remove a task subscriber from the communicator's default queue"""
+        """Remove a task subscriber from the communicator's default queue.
+
+        :param identifier: the subscriber to remove
+        :raises: ValueError if identifier does not correspond to a known subscriber
+        """
 
     @abc.abstractmethod
-    def add_broadcast_subscriber(self, subscriber: types.BroadcastSubscriber, identifier=None):
+    def add_broadcast_subscriber(self, subscriber: types.BroadcastSubscriber, identifier=None) -> Any:
         """
         Add a broadcast subscriber that will receive all broadcast messages
 
@@ -123,12 +127,13 @@ class CommunicatorHelper(Communicator):
         del self._broadcast_subscribers
         del self._rpc_subscribers
 
-    def add_rpc_subscriber(self, subscriber, identifier=None):
+    def add_rpc_subscriber(self, subscriber, identifier=None) -> Any:
         self._ensure_open()
         identifier = identifier or shortuuid.uuid()
         if identifier in self._rpc_subscribers:
             raise exceptions.DuplicateSubscriberIdentifier("RPC identifier '{}'".format(identifier))
         self._rpc_subscribers[identifier] = subscriber
+        return identifier
 
     def remove_rpc_subscriber(self, identifier):
         self._ensure_open()
@@ -155,15 +160,16 @@ class CommunicatorHelper(Communicator):
         """
         Remove a task subscriber
 
-        :param identifier: The task subscriber identifier
+        :param identifier: the subscriber to remove
+        :raises: ValueError if identifier does not correspond to a known subscriber
         """
         self._ensure_open()
         try:
             self._task_subscribers.pop(identifier)
-        except ValueError:
+        except KeyError:
             raise ValueError("Unknown subscriber: '{}'".format(identifier))
 
-    def add_broadcast_subscriber(self, subscriber, identifier=None):
+    def add_broadcast_subscriber(self, subscriber: types.BroadcastSubscriber, identifier=None) -> Any:
         self._ensure_open()
         identifier = identifier or shortuuid.uuid()
         if identifier in self._broadcast_subscribers:

--- a/kiwipy/exceptions.py
+++ b/kiwipy/exceptions.py
@@ -1,9 +1,7 @@
 import concurrent.futures
 
-__all__ = [
-    'RemoteException', 'DeliveryFailed', 'TaskRejected', 'UnroutableError', 'TimeoutError',
-    'DuplicateSubscriberIdentifier', 'CommunicatorClosed', 'InvalidStateError', 'QueueEmpty'
-]
+__all__ = ('RemoteException', 'DeliveryFailed', 'TaskRejected', 'UnroutableError', 'TimeoutError',
+           'DuplicateSubscriberIdentifier', 'CommunicatorClosed', 'InvalidStateError', 'QueueEmpty')
 
 
 class RemoteException(Exception):

--- a/kiwipy/filters.py
+++ b/kiwipy/filters.py
@@ -1,7 +1,7 @@
 import re
 import typing
 
-__all__ = ['BroadcastFilter']
+__all__ = ('BroadcastFilter',)
 
 
 class BroadcastFilter:

--- a/kiwipy/futures.py
+++ b/kiwipy/futures.py
@@ -2,7 +2,7 @@ import concurrent.futures
 import contextlib
 import logging
 
-__all__ = ['Future', 'chain', 'copy_future', 'CancelledError', 'capture_exceptions', 'wait', 'as_completed']
+__all__ = 'Future', 'chain', 'copy_future', 'CancelledError', 'capture_exceptions', 'wait', 'as_completed'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/kiwipy/local.py
+++ b/kiwipy/local.py
@@ -1,6 +1,6 @@
 from . import communications
 
-__all__ = ['LocalCommunicator']
+__all__ = ('LocalCommunicator',)
 
 
 class LocalCommunicator(communications.CommunicatorHelper):

--- a/kiwipy/rmq/defaults.py
+++ b/kiwipy/rmq/defaults.py
@@ -2,6 +2,7 @@ from functools import partial
 import yaml
 
 # Times are in milliseconds
+MILLI_TO_SECONDS = 1000
 
 TASK_EXCHANGE = 'kiwipy.tasks'
 TASK_QUEUE = 'kiwipy.tasks'
@@ -12,11 +13,11 @@ RPC_TOPIC = '[rpc]'
 # 3.5 (as present in Ubuntu 16.04) and likely earlier.  If you have a newer version of RabbitMQ
 # it's fine to set this lower.  See:
 # https://github.com/mosquito/aio-pika/issues/165
-MESSAGE_TTL = 66 * 1000
-TEST_QUEUE_EXPIRES = 10 * 1000
-QUEUE_EXPIRES = 60 * 1000
-REPLY_QUEUE_EXPIRES = 60 * 1000
-TASK_MESSAGE_TTL = 60000 * 60 * 24 * 7  # One week
+MESSAGE_TTL = 66 * MILLI_TO_SECONDS
+TEST_QUEUE_EXPIRES = 10 * MILLI_TO_SECONDS
+QUEUE_EXPIRES = 60 * MILLI_TO_SECONDS
+REPLY_QUEUE_EXPIRES = 60 * MILLI_TO_SECONDS
+TASK_MESSAGE_TTL = 60 * MILLI_TO_SECONDS * 60 * 24 * 7  # One week
 TASK_PREFETCH_SIZE = 0
 TASK_PREFETCH_COUNT = 0
 TASK_FETCH_TIMEOUT = 5.

--- a/kiwipy/rmq/defaults.py
+++ b/kiwipy/rmq/defaults.py
@@ -2,7 +2,7 @@ from functools import partial
 import yaml
 
 # Times are in milliseconds
-MILLI_TO_SECONDS = 1000
+SECONDS_TO_MILLISECONDS = 1000
 
 TASK_EXCHANGE = 'kiwipy.tasks'
 TASK_QUEUE = 'kiwipy.tasks'
@@ -13,11 +13,11 @@ RPC_TOPIC = '[rpc]'
 # 3.5 (as present in Ubuntu 16.04) and likely earlier.  If you have a newer version of RabbitMQ
 # it's fine to set this lower.  See:
 # https://github.com/mosquito/aio-pika/issues/165
-MESSAGE_TTL = 66 * MILLI_TO_SECONDS
-TEST_QUEUE_EXPIRES = 10 * MILLI_TO_SECONDS
-QUEUE_EXPIRES = 60 * MILLI_TO_SECONDS
-REPLY_QUEUE_EXPIRES = 60 * MILLI_TO_SECONDS
-TASK_MESSAGE_TTL = 60 * MILLI_TO_SECONDS * 60 * 24 * 7  # One week
+MESSAGE_TTL = 66 * SECONDS_TO_MILLISECONDS
+TEST_QUEUE_EXPIRES = 10 * SECONDS_TO_MILLISECONDS
+QUEUE_EXPIRES = 60 * SECONDS_TO_MILLISECONDS
+REPLY_QUEUE_EXPIRES = 60 * SECONDS_TO_MILLISECONDS
+TASK_MESSAGE_TTL = 60 * SECONDS_TO_MILLISECONDS * 60 * 24 * 7  # One week
 TASK_PREFETCH_SIZE = 0
 TASK_PREFETCH_COUNT = 0
 TASK_FETCH_TIMEOUT = 5.

--- a/kiwipy/rmq/messages.py
+++ b/kiwipy/rmq/messages.py
@@ -243,8 +243,8 @@ class BasePublisherWithReplyQueue:
             else:
                 utils.response_to_future(response, response_future)
                 try:
-                    # If the response was a future it means we should another message that resolves
-                    # that future
+                    # If the response was a future it means we should get another message that
+                    # resolves that future
                     if asyncio.isfuture(response_future.result()):
                         self._awaiting_response[correlation_id] = response_future.result()
                 except Exception:  # pylint: disable=broad-except

--- a/kiwipy/rmq/tasks.py
+++ b/kiwipy/rmq/tasks.py
@@ -75,7 +75,10 @@ class RmqTaskSubscriber(messages.BaseConnectionWithExchange):
         return identifier
 
     async def remove_task_subscriber(self, identifier):
-        self._subscribers.pop(identifier)
+        try:
+            self._subscribers.pop(identifier)
+        except KeyError:
+            raise ValueError("Unknown task subscriber '{}'".format(identifier))
         if not self._subscribers:
             await self._task_queue.cancel(self._consumer_tag)
             self._consumer_tag = None

--- a/kiwipy/rmq/utils.py
+++ b/kiwipy/rmq/utils.py
@@ -35,14 +35,12 @@ def result_response(result):
     return {RESULT_KEY: result}
 
 
-def exception_response(exception, trace=None):
+def exception_response(exception: Exception, trace=None) -> dict:
     """
     Create an exception response dictionary
     :param exception: The exception to encode
-    :type exception: :class:`Exception`
     :param trace: Optional traceback
-    :return: A response dictionary
-    :rtype: dict
+    :return: An exception response dictionary
     """
     msg = str(exception)
     if trace is not None:

--- a/kiwipy/types.py
+++ b/kiwipy/types.py
@@ -1,0 +1,10 @@
+from typing import Callable, Any
+
+import kiwipy  # pylint: disable=unused-import
+
+# RPC subscriber params: communicator, msg
+RpcSubscriber = Callable[['kiwipy.Communicator', Any], Any]
+# Task subscriber params: communicator, task
+TaskSubscriber = Callable[['kiwipy.Communicator', Any], Any]
+# Broadcast subscribers params: communicator, body, sender, subject, correlation id
+BroadcastSubscriber = Callable[['kiwipy.Communicator', Any, Any, Any, Any], Any]

--- a/kiwipy/utils.py
+++ b/kiwipy/utils.py
@@ -1,7 +1,7 @@
 import logging
 import traceback
 
-__all__ = ['EventHelper']
+__all__ = ('EventHelper',)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/kiwipy/version.py
+++ b/kiwipy/version.py
@@ -1,3 +1,3 @@
 __version__ = "0.5.3"
 
-__all__ = ['__version__']
+__all__ = ('__version__',)

--- a/setup.py
+++ b/setup.py
@@ -2,51 +2,55 @@
 from setuptools import setup
 
 __author__ = "Martin Uhrin"
-__license__ = "GPLv3 and MIT, see LICENSE file"
-__contributors__ = "Sebastiaan Huber"
+__license__ = "GPLv3 and MIT"
+__contributors__ = "Sebastiaan P. Huber"
 
 about = {}
 with open('kiwipy/version.py') as f:
     exec(f.read(), about)
 
-setup(name="kiwipy",
-      version=about['__version__'],
-      description='A python remote communications library',
-      long_description=open('README.rst').read(),
-      url='https://github.com/muhrin/kiwipy.git',
-      author='Martin Uhrin',
-      author_email='martin.uhrin.10@ucl.ac.uk',
-      license=__license__,
-      classifiers=[
-          'Development Status :: 4 - Beta',
-          'License :: OSI Approved :: MIT License',
-          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-      ],
-      keywords='communication messaging rpc broadcast',
-      install_requires=['shortuuid', 'async_generator', 'pytray~=0.2'],
-      python_requires=">=3.5",
-      extras_require={
-          'rmq': ['aio-pika', 'pyyaml~=5.1'],
-          'dev': [
-              'pip',
-              'pre-commit',
-              'pytest>=4',
-              'pytest-asyncio<=0.10.0',
-              'pytest-cov',
-              'ipython<6',
-              'twine',
-              'yapf',
-              'prospector',
-              'pylint',
-          ],
-          "docs": [
-              "Sphinx==1.8.4",
-              "Pygments==2.3.1",
-              "docutils==0.14",
-          ],
-      },
-      packages=['kiwipy', 'kiwipy.rmq'],
-      test_suite='test')
+setup(
+    name="kiwipy",
+    version=about['__version__'],
+    description='A python remote communications library',
+    long_description=open('README.rst').read(),
+    url='https://github.com/muhrin/kiwipy.git',
+    author='Martin Uhrin',
+    author_email='martin.uhrin.10@ucl.ac.uk',
+    license=__license__,
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
+    keywords='communication messaging rpc broadcast',
+    install_requires=['shortuuid', 'async_generator', 'pytray>=0.2.2, <0.3.0'],
+    python_requires=">=3.5",
+    extras_require={
+        'rmq': ['aio-pika', 'pyyaml~=5.1'],
+        'dev': [
+            'pip',
+            'pre-commit',
+            'pytest>=4',
+            'pytest-asyncio<=0.10.0',
+            'twine',
+            'yapf',
+            'prospector',
+            'pylint',
+            'pytest-cov',
+            'sphinx',
+        ],
+        'docs': [
+            'nbsphinx',  # Jupyter notebooks in docs
+            'jupyter<6',  # For running doc examples
+            'sphinx-autobuild',
+            "docutils==0.14",
+            "Pygments==2.3.1",
+            'pandoc'
+        ]
+    },
+    packages=['kiwipy', 'kiwipy.rmq'],
+    test_suite='test')

--- a/test/rmq/test_rmq_thread_communicator.py
+++ b/test/rmq/test_rmq_thread_communicator.py
@@ -8,6 +8,7 @@ import kiwipy
 from kiwipy import rmq
 
 from ..utils import CommunicatorTester
+from . import utils
 
 # pylint: disable=invalid-name, redefined-outer-name
 
@@ -85,7 +86,7 @@ class TestRmqThreadCommunicator(CommunicatorTester, unittest.TestCase):
             tasks.append(task)
             return result_future
 
-        task_queue = self.communicator.task_queue('test-queue')
+        task_queue = self.communicator.task_queue('test-queue-{}'.format(utils.rand_string(5)))
 
         task_queue.add_task_subscriber(on_task)
         task_future = task_queue.task_send(TASK).result(timeout=self.WAIT_TIMEOUT)
@@ -103,7 +104,7 @@ class TestRmqThreadCommunicator(CommunicatorTester, unittest.TestCase):
         RESULT = 42
 
         # Create a new queue and sent the task
-        task_queue = self.communicator.task_queue('test-queue')
+        task_queue = self.communicator.task_queue('test-queue-{}'.format(utils.rand_string(5)))
         task_future = task_queue.task_send(TASK)
 
         # Get the task and carry it out
@@ -174,8 +175,8 @@ def test_queue_iter_not_process(thread_task_queue: rmq.RmqThreadTaskQueue):
 def test_queue_task_forget(thread_task_queue: rmq.RmqThreadTaskQueue):
     """
     Check what happens when we forget to process a task we said we would
-    WARNING: This test mail fail when running with a debugger as it relies on the 'outcome' reference
-    count dropping to zero but the debugger may be preventing this.
+    WARNING: This test mail fail when running with a debugger as it relies on the 'outcome'
+    reference count dropping to zero but the debugger may be preventing this.
     """
     outcomes = list()
 

--- a/test/rmq/test_tasks.py
+++ b/test/rmq/test_tasks.py
@@ -252,8 +252,8 @@ async def test_queue_iter_not_process(task_queue: rmq.RmqTaskQueue):
 async def test_queue_task_forget(task_queue: rmq.RmqTaskQueue):
     """
     Check what happens when we forget to process a task we said we would
-    WARNING: This test mail fail when running with a debugger as it relies on the 'outcome' reference
-    count dropping to zero but the debugger may be preventing this.
+    WARNING: This test mail fail when running with a debugger as it relies on the 'outcome'
+    reference count dropping to zero but the debugger may be preventing this.
     """
     outcomes = list()
 
@@ -265,7 +265,7 @@ async def test_queue_task_forget(task_queue: rmq.RmqTaskQueue):
         outcome = task.process()
 
     with pytest.raises(kiwipy.exceptions.QueueEmpty):
-        async with task_queue.next_task():
+        async with task_queue.next_task(timeout=1.):
             pass
 
     # Now let's 'forget' i.e. lose the outcome

--- a/test/rmq/utils.py
+++ b/test/rmq/utils.py
@@ -1,3 +1,6 @@
+import random
+import string
+
 import shortuuid
 
 import kiwipy
@@ -19,3 +22,7 @@ async def new_communicator(connection, settings=None) -> kiwipy.rmq.RmqCommunica
                                        **settings)
     await communicator.connect()
     return communicator
+
+
+def rand_string(length):
+    return ''.join(random.choice(string.ascii_letters) for _ in range(length))

--- a/test/utils.py
+++ b/test/utils.py
@@ -235,6 +235,10 @@ class CommunicatorTester(metaclass=abc.ABCMeta):
         with pytest.raises(kiwipy.TimeoutError):
             fut.result(0.01)
 
+    def test_remove_unknown_task_subscriber(self):
+        with pytest.raises(ValueError):
+            self.communicator.remove_task_subscriber('unknown')
+
     # endregion
 
     # region Broadcast

--- a/test/utils.py
+++ b/test/utils.py
@@ -7,6 +7,8 @@ that all caps 'variable' names mean that it's a constant.
 
 import abc
 
+import pytest
+
 import kiwipy
 
 
@@ -14,7 +16,7 @@ class CommunicatorTester(metaclass=abc.ABCMeta):
     # Disable invalid name because I use caps for constants which the linter doesn't like
     # also disable no-member for superclass calls because we use this as a mixin that gets used
     # with unittest.TestCase
-    # pylint: disable=invalid-name, no-member
+    # pylint: disable=invalid-name, no-member, too-many-public-methods
 
     WAIT_TIMEOUT = 5.
 
@@ -39,7 +41,8 @@ class CommunicatorTester(metaclass=abc.ABCMeta):
         pass
 
     def test_close(self):
-        """Make sure a closed communicator raises when trying to perform any communication operation"""
+        """Make sure a closed communicator raises when trying to perform any communication
+        operation"""
         self.communicator.close()
         with self.assertRaises(kiwipy.CommunicatorClosed):
             self.communicator.add_rpc_subscriber(None, 'rpc')
@@ -219,6 +222,18 @@ class CommunicatorTester(metaclass=abc.ABCMeta):
         self.assertEqual(1, len(tasks))
         self.assertEqual(TASK, tasks[0])
         self.assertEqual(RESULT, result)
+
+    def test_add_remove_task_subscriber(self):
+
+        def worker(*_, **__):
+            pass
+
+        worker_id = self.communicator.add_task_subscriber(worker)
+        self.communicator.remove_task_subscriber(worker_id)
+
+        fut = self.communicator.task_send('task')
+        with pytest.raises(kiwipy.TimeoutError):
+            fut.result(0.01)
 
     # endregion
 


### PR DESCRIPTION
This should go on top of #43.

WARNING: This commit introduces API change

Removing RMQ task subscribers was failing beacuse of the way we used to
wrap the function to get it to play nice in the event loop.  Then when
the user would give us the function to unsubscribe we couldn't find it
because, in fact, we held a wrapped function, not the original.

For the sake of simplicity the API has been changed to that of broadcast
and RPC where the user either supplies or is given a unique identifier
which can later be used to remove the subscriber.

This API change will only cause problems for clients that were removing
task subscribers manually (rather than just closing the communicator).
I believe AiiDA just closes the communicator and so should not require
any changes.

Related bug fixed: exceptions in tasks were not propagating the error
message to the RemoteException because of a bug in IncomingMessage.
This is fixed.

Tests added.