### PR TITLE
Feature: Added global kiwipy.connect factory

### DIFF
--- a/examples/rmq_broadcast_client.py
+++ b/examples/rmq_broadcast_client.py
@@ -1,21 +1,21 @@
 import sys
 
-from kiwipy import rmq
+import kiwipy
 
 # pylint: disable=invalid-name
 
 body = ' '.join(sys.argv[1:]) or "___"
 
-with rmq.RmqThreadCommunicator.connect(connection_params={'url': 'amqp://127.0.0.1'}) as communicator:
+with kiwipy.connect('amqp://127.0.0.1') as comm:
     # send message with different sender and subject
 
     # listen by two subscriber
     sendr = 'bob.jones'
     subj = 'purchase.car'
-    communicator.broadcast_send(body, sender=sendr, subject=subj)
+    comm.broadcast_send(body, sender=sendr, subject=subj)
 
     # Filtered by filter subscriber because subject not matched with "purchase.*" pattern
     # Therefore filterd.
     sendr = 'bob.jones'
     subj = 'sell.car'
-    communicator.broadcast_send(body, sender=sendr, subject=subj)
+    comm.broadcast_send(body, sender=sendr, subject=subj)

--- a/examples/rmq_broadcast_server.py
+++ b/examples/rmq_broadcast_server.py
@@ -1,15 +1,14 @@
 import threading
 
 import kiwipy
-from kiwipy import rmq
 
 
-def on_broadcast_send(_, body, sender, subject, __):
+def on_broadcast_send(_comm, body, sender, subject, __):
     print(" [x] listening on_broadcast_send:")
     print(" body: {}, sender {}, subject {}\n".format(body, sender, subject))
 
 
-def on_broadcast_filter(_, body, sender=None, subject=None, __=None):
+def on_broadcast_filter(_comm, body, sender=None, subject=None, __=None):
     print(" [x] listening on_broadcast_filter:")
     print(" body: {}, sender {}, subject {}\n".format(body, sender, subject))
 
@@ -19,11 +18,11 @@ if __name__ == "__main__":
     filtered.add_subject_filter("purchase.*")
 
     try:
-        with rmq.RmqThreadCommunicator.connect(connection_params={'url': 'amqp://127.0.0.1'}) as communicator:
+        with kiwipy.connect('amqp://127.0.0.1') as comm:
             # Register a broadcast subscriber
-            communicator.add_broadcast_subscriber(on_broadcast_send)
+            comm.add_broadcast_subscriber(on_broadcast_send)
             # Register a broadcast subscriber
-            communicator.add_broadcast_subscriber(filtered)
+            comm.add_broadcast_subscriber(filtered)
             # Now wait indefinitely for fibonacci calls
             threading.Event().wait()
     except KeyboardInterrupt:

--- a/examples/rmq_new_task.py
+++ b/examples/rmq_new_task.py
@@ -1,11 +1,11 @@
 import sys
 
-from kiwipy import rmq
+import kiwipy
 
 # pylint: disable=invalid-name
 
 message = ' '.join(sys.argv[1:]) or "Hello World!"
 
-with rmq.RmqThreadCommunicator.connect(connection_params={'url': 'amqp://127.0.0.1'}) as communicator:
-    result = communicator.task_send(message).result(timeout=5.0)
+with kiwipy.connect('amqp://127.0.0.1') as comm:
+    result = comm.task_send(message).result(timeout=5.0)
     print(result)

--- a/examples/rmq_rpc_client.py
+++ b/examples/rmq_rpc_client.py
@@ -1,15 +1,14 @@
-from kiwipy import rmq
+import kiwipy
 
 # pylint: disable=invalid-name
 
-communicator = rmq.RmqThreadCommunicator.connect(connection_params={'url': 'amqp://127.0.0.1'})
+with kiwipy.connect('amqp://127.0.0.1') as comm:
+    # Send an RPC message with identifier 'fib'
+    print(" [x] Requesting fib(30)")
+    response = comm.rpc_send('fib', 30).result()
+    print((" [.] Got %r" % response))
 
-# Send an RPC message with identifier 'fib'
-print(" [x] Requesting fib(30)")
-response = communicator.rpc_send('fib', 30).result()
-print((" [.] Got %r" % response))
-
-# Send an RPC message with identifier 'fac'
-print(" [x] Requesting fac(3)")
-response = communicator.rpc_send('fac', 3).result()
-print((" [.] Got %r" % response))
+    # Send an RPC message with identifier 'fac'
+    print(" [x] Requesting fac(3)")
+    response = comm.rpc_send('fac', 3).result()
+    print((" [.] Got %r" % response))

--- a/examples/rmq_rpc_server.py
+++ b/examples/rmq_rpc_server.py
@@ -1,30 +1,30 @@
 import threading
 
-from kiwipy import rmq
+import kiwipy
 
 
-def fib(comm, num):
+def fib(_comm, num):
     if num == 0:
         return 0
     if num == 1:
         return 1
-    return fib(comm, num - 1) + fib(comm, num - 2)
+    return fib(_comm, num - 1) + fib(_comm, num - 2)
 
 
-def fac(comm, num):
+def fac(_comm, num):
     result = 1
     if num > 1:
-        result = num * fac(comm, num - 1)
+        result = num * fac(_comm, num - 1)
     return result
 
 
 if __name__ == "__main__":
     try:
-        with rmq.RmqThreadCommunicator.connect(connection_params={'url': 'amqp://127.0.0.1'}) as communicator:
+        with kiwipy.connect('amqp://127.0.0.1') as comm:
             # Register an RPC subscriber with the name 'fib'
-            communicator.add_rpc_subscriber(fib, 'fib')
+            comm.add_rpc_subscriber(fib, 'fib')
             # Register an RPC subscriber with the name 'fac'
-            communicator.add_rpc_subscriber(fac, 'fac')
+            comm.add_rpc_subscriber(fac, 'fac')
             # Now wait indefinitely for fibonacci calls
             threading.Event().wait()
     except KeyboardInterrupt:

--- a/examples/rmq_worker.py
+++ b/examples/rmq_worker.py
@@ -1,7 +1,7 @@
 import time
 import threading
 
-from kiwipy import rmq
+import kiwipy
 
 print(' [*] Waiting for messages. To exit press CTRL+C')
 
@@ -13,6 +13,9 @@ def callback(_comm, task):
     return task
 
 
-with rmq.RmqThreadCommunicator.connect(connection_params={'url': 'amqp://127.0.0.1/'}) as communicator:
+with kiwipy.connect('amqp://127.0.0.1/') as communicator:
     communicator.add_task_subscriber(callback)
-    threading.Event().wait()
+    try:
+        threading.Event().wait()
+    except KeyboardInterrupt:
+        pass

--- a/kiwipy/__init__.py
+++ b/kiwipy/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 # pylint: disable=redefined-builtin, undefined-variable
 from .communications import *
+from .communicate import *
 from .exceptions import *
 from .filters import *
 from .futures import *
@@ -10,7 +11,7 @@ from .utils import *
 from .version import *
 
 __all__ = (exceptions.__all__ + futures.__all__ + communications.__all__ + version.__all__ + utils.__all__ +
-           local.__all__ + filters.__all__)
+           local.__all__ + filters.__all__ + communicate.__all__)
 
 
 # Do this se we don't get the "No handlers could be found..." warnings that will be produced

--- a/kiwipy/communicate.py
+++ b/kiwipy/communicate.py
@@ -1,0 +1,12 @@
+__all__ = ('connect',)
+
+DEFAULT_COMM_URI = 'amqp://guest:guest@127.0.0.1/'
+
+
+def connect(uri: str = DEFAULT_COMM_URI, **kwargs):
+    """Create a connection using a URI"""
+    if uri.startswith('amqp'):
+        from . import rmq  # Avoid circular ref: pylint: disable=import-outside-toplevel
+        return rmq.connect(connection_params=uri, **kwargs)
+
+    raise ValueError("Uknown communicator uri '{}'".format(uri))

--- a/kiwipy/communications.py
+++ b/kiwipy/communications.py
@@ -18,6 +18,12 @@ class Communicator:
     The interface for a communicator used to both send and receive various types of message.
     """
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     @abc.abstractmethod
     def is_closed(self) -> bool:
         """Return `True` if the communicator was closed"""

--- a/kiwipy/rmq/threadcomms.py
+++ b/kiwipy/rmq/threadcomms.py
@@ -4,6 +4,7 @@ import concurrent.futures
 from concurrent.futures import Future as ThreadFuture
 import functools
 import logging
+from typing import Union
 
 import aio_pika
 import pamqp
@@ -14,7 +15,7 @@ from . import defaults
 from . import communicator
 from . import tasks
 
-__all__ = ('RmqThreadCommunicator', 'RmqThreadTaskQueue', 'connect')
+__all__ = 'RmqThreadCommunicator', 'RmqThreadTaskQueue', 'connect'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class RmqThreadCommunicator(kiwipy.Communicator):
 
     @classmethod
     def connect(cls,
-                connection_params: [str, dict] = None,
+                connection_params: Union[str, dict] = None,
                 connection_factory=aio_pika.connect_robust,
                 loop=None,
                 message_exchange=defaults.MESSAGE_EXCHANGE,
@@ -304,7 +305,7 @@ class RmqThreadIncomingTask:
             yield outcome
 
 
-def connect(connection_params: [str, dict] = None,
+def connect(connection_params: Union[str, dict] = None,
             connection_factory=aio_pika.connect_robust,
             loop=None,
             message_exchange=defaults.MESSAGE_EXCHANGE,

--- a/kiwipy/rmq/threadcomms.py
+++ b/kiwipy/rmq/threadcomms.py
@@ -117,6 +117,7 @@ class RmqThreadCommunicator(kiwipy.Communicator):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
+        self.close()
 
     def loop(self):
         return self._loop

--- a/test/utils.py
+++ b/test/utils.py
@@ -57,6 +57,12 @@ class CommunicatorTester(metaclass=abc.ABCMeta):
         with self.assertRaises(kiwipy.CommunicatorClosed):
             self.communicator.broadcast_send(None)
 
+    def test_context(self):
+        assert not self.communicator.is_closed()
+        with self.communicator:
+            pass
+        assert self.communicator.is_closed()
+
     # region RPC
 
     def test_rpc_send_receive(self):


### PR DESCRIPTION
This uses the URI to determine which backend to use (we only have the
RMQ one anyway) and passes any other arguments on to the corresponding
communicator.  This makes it easier for someone to create a communicator
and also promotes abstraction by seperating the client from the concrete
class that the URI will resolve to.