### PR TITLE
Fixed jupyter problem with RmqThreadCommunicator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 script:
-  - pytest --cov=kiwipy test
+  - pytest --cov=kiwipy -p no:nb_regression test
 
 after_success:
   - coverage report

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,6 +88,7 @@ html_theme = 'alabaster'
 #
 # html_theme_options = {}
 html_theme_options = {
+    'analytics_id': 'UA-17296547-4',
     'codecov_button': True,
     'description': 'Robust, high-volume, message based communication made easy',
     'github_button': True,

--- a/kiwipy/rmq/tasks.py
+++ b/kiwipy/rmq/tasks.py
@@ -171,6 +171,7 @@ class RmqTaskSubscriber(messages.BaseConnectionWithExchange):
                 except Exception as exc:  # pylint: disable=broad-except
                     # There was an exception during the processing of this task
                     outcome.set_exception(exc)
+                    _LOGGER.exception("Exception occurred while processing task.")
                 else:
                     # All good
                     outcome.set_result(result)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
             'pre-commit',
             'pytest>=4',
             'pytest-asyncio<=0.10.0',
+            'pytest-notebook',
             'twine',
             'yapf',
             'prospector',

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:distutils:
+    ignore::DeprecationWarning:aio_pika:
+    ignore::DeprecationWarning:pytest_asyncio:

--- a/test/rmq/conftest.py
+++ b/test/rmq/conftest.py
@@ -1,6 +1,11 @@
+import os
+
 import pytest
 
 from . import utils
+
+ENV_KIWI_RMQ_URI = 'KIWIPY_TEST_RMQ_URI'
+DEFAULT_RMQ_URI = 'amqp://guest:guest@127.0.0.1:5672/'
 
 try:
     import aio_pika
@@ -9,16 +14,20 @@ try:
     # pylint: disable=redefined-outer-name
 
     @pytest.fixture
+    def connection_params() -> dict:
+        return {'url': os.environ.get(ENV_KIWI_RMQ_URI, DEFAULT_RMQ_URI)}
+
+    @pytest.fixture
     @async_generator
-    async def connection():
-        conn = await aio_pika.connect_robust('amqp://guest:guest@localhost:5672/')
+    async def connection(connection_params: dict):
+        conn = await aio_pika.connect_robust(**connection_params)
         await yield_(conn)
         await conn.close()
 
     @pytest.fixture
     @async_generator
-    async def communicator(connection):
-        communicator = await utils.new_communicator(connection)
+    async def communicator(connection_params):
+        communicator = await utils.new_communicator(connection_params)
         await yield_(communicator)
         await communicator.disconnect()
 

--- a/test/rmq/notebooks/communicator.ipynb
+++ b/test/rmq/notebooks/communicator.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Got your message: hello!\n"
+     ]
+    }
+   ],
+   "source": [
+    "import kiwipy\n",
+    "\n",
+    "comm = kiwipy.connect('amqp://127.0.0.1')\n",
+    "\n",
+    "\n",
+    "def rpc_call(_comm, msg):\n",
+    "    print(\"Got your message: {}\".format(msg))\n",
+    "    return \"Thanks!\"\n",
+    "\n",
+    "\n",
+    "comm.add_rpc_subscriber(rpc_call, 'tester')\n",
+    "\n",
+    "response = comm.rpc_send('tester', 'hello!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Thanks!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response.result())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "comm.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comm.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Thanks!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response.result())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comm.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": [
+     "# %%\n",
+     "\n",
+     "import kiwipy\n",
+     "\n",
+     "comm = kiwipy.connect('amqp://127.0.0.1')\n",
+     "\n",
+     "\n",
+     "def rpc_call(_comm, msg):\n",
+     "    print(\"Got your message: {}\".format(msg))\n",
+     "    return \"Thanks!\"\n",
+     "\n",
+     "\n",
+     "comm.add_rpc_subscriber(rpc_call, 'tester')\n",
+     "\n",
+     "response = comm.rpc_send('tester', 'hello!')\n",
+     "\n",
+     "# %%\n",
+     "\n",
+     "print(response.result())\n",
+     "\n",
+     "# %%\n",
+     "\n",
+     "comm.close()\n"
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/test/rmq/test_coroutine_communicator.py
+++ b/test/rmq/test_coroutine_communicator.py
@@ -162,9 +162,9 @@ async def test_broadcast_filter_sender_and_subject(communicator: kiwipy.rmq.RmqC
 
 
 @pytest.mark.asyncio
-async def test_add_remove_broadcast_subscriber(connection: kiwipy.rmq.RmqCommunicator):
+async def test_add_remove_broadcast_subscriber(connection_params):
     # Set the expiry to something small so we know that the queues expire after we unsubscribe
-    communicator = await utils.new_communicator(connection, settings={'queue_expires': 1})
+    communicator = await utils.new_communicator(connection_params, settings={'queue_expires': 1})
 
     async with communicator:
         broadcast_received = asyncio.Future()

--- a/test/rmq/test_rmq_thread_communicator.py
+++ b/test/rmq/test_rmq_thread_communicator.py
@@ -1,4 +1,6 @@
+# pylint: disable=invalid-name, redefined-outer-name
 import concurrent.futures
+import sys
 import unittest
 
 import shortuuid
@@ -10,7 +12,6 @@ from kiwipy import rmq
 from ..utils import CommunicatorTester
 from . import utils
 
-# pylint: disable=invalid-name, redefined-outer-name
 
 WAIT_TIMEOUT = 5.
 
@@ -226,3 +227,17 @@ def test_task_processing_exception(thread_task_queue: rmq.RmqThreadTaskQueue):
     with pytest.raises(kiwipy.QueueEmpty):
         with thread_task_queue.next_task(timeout=1.):
             pass
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason='`pytest-notebook` plugin requires Python >= 3.6')
+def test_jupyter_notebook():
+    """Test that the `RmqThreadCommunicator` can be used in a Jupyter notebook."""
+    import os
+    from pytest_notebook.nb_regression import NBRegressionFixture
+
+    fixture = NBRegressionFixture(exec_timeout=50)
+    fixture.diff_color_words = False
+    fixture.diff_ignore = ('/metadata/language_info/version',)
+
+    with open(os.path.abspath('test/rmq/notebooks/communicator.ipynb')) as handle:
+        fixture.check(handle)

--- a/test/rmq/utils.py
+++ b/test/rmq/utils.py
@@ -7,21 +7,19 @@ import kiwipy
 from kiwipy import rmq
 
 
-async def new_communicator(connection, settings=None) -> kiwipy.rmq.RmqCommunicator:
+async def new_communicator(connection_params, settings=None) -> kiwipy.rmq.RmqCommunicator:
     settings = settings or {}
 
     message_exchange = "{}.{}".format(__file__, shortuuid.uuid())
     task_exchange = "{}.{}".format(__file__, shortuuid.uuid())
     task_queue = "{}.{}".format(__file__, shortuuid.uuid())
 
-    communicator = rmq.RmqCommunicator(connection,
-                                       message_exchange=message_exchange,
-                                       task_exchange=task_exchange,
-                                       task_queue=task_queue,
-                                       testing_mode=True,
-                                       **settings)
-    await communicator.connect()
-    return communicator
+    return await rmq.async_connect(connection_params,
+                                   message_exchange=message_exchange,
+                                   task_exchange=task_exchange,
+                                   task_queue=task_queue,
+                                   testing_mode=True,
+                                   **settings)
 
 
 def rand_string(length):


### PR DESCRIPTION
Fixes #52 

Changed connect() so that now it pipes the arguments through to the
class which will spin up the event loop in a separate thread when
start() is called and at that point connect to RMQ.  This way, all the
loop stuff is being done on the separate thread the jupyter is happy.

This necessitated changing the constructor signature for both
RmqCommunicator and RmqThreadCommunicator, however the respective
connect() function signatures remain unchanged.

Added an async_connect() that creates an RmqCommunicator mirroring the
threaded version.  Updated the tests to use this.

Also made it possible to use an environmental variable to change the
RabbitMQ URI because, e.g., gitlab CI doesn't use 'localhost'.

Added jupyter notebook test - this used to fail because of the loop
issues using RmqThreadCommunicator.  It needs to be ran interactively
though.