### PR TITLE
Add explicit compatibility for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 
 install:
   - pip install .[rmq,dev]

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords='communication messaging rpc broadcast',
     install_requires=['shortuuid', 'async_generator', 'pytray>=0.2.2, <0.3.0'],


### PR DESCRIPTION
Fixes #054

~~Note that I intentionally did not update the `python_requires` in the `setup.py` as this wiil prevent it from being installed with py3.5 even though it is *technically* still compatible. We just don't run the CI anymore for this version~~

The original problem of compatibility was fixed in the same PR #50  that introduced it. So there is no need to drop Py3.5 compatibility anymore. Therefore we are just adding explicit Py3.8 compatibility