### PR TITLE
Revert "Increase the default TTL for task messages (#59)"

### DIFF
--- a/kiwipy/rmq/defaults.py
+++ b/kiwipy/rmq/defaults.py
@@ -13,7 +13,10 @@ MESSAGE_TTL = 60 * 1000  # One minute
 TEST_QUEUE_EXPIRES = 10 * 1000
 QUEUE_EXPIRES = 60 * 1000
 REPLY_QUEUE_EXPIRES = 60 * 1000
-TASK_MESSAGE_TTL = 60000 * 60 * 24 * 7 * 120  # 120 days
+
+# Warning: changing the message TTL will make it impossible to connect to an existing queue with the old value.
+# If it is persistent it will have to be manually deleted before one can create a new one and connect to it again.
+TASK_MESSAGE_TTL = 60000 * 60 * 24 * 7  # One week
 TASK_PREFETCH_SIZE = 0
 TASK_PREFETCH_COUNT = 0
 


### PR DESCRIPTION
Fixes #60 

This reverts commit 42fb6f893c4bd150757e0cd0cef8c6b195b00007.
Changing the TTL of messages of the task queue was necessary because the
original value of 7 days was not sufficient for the AiiDA use case.
However, when this parameter is changed, one cannot connect to an
existing queue that was configured with the old value. The only way is
to destroy the queue and create a new one. Since this is not feasible
through a Python API, let alone in an automated fashion, this will
render all upgraded AiiDA installations completely broken. The only
solution is to temporarily revert it to the original value.