### PR TITLE
Return identifier from `CommunicatorHelper.add_rpc_subscriber`

### DIFF
--- a/kiwipy/communications.py
+++ b/kiwipy/communications.py
@@ -133,6 +133,7 @@ class CommunicatorHelper(Communicator):
         if identifier in self._rpc_subscribers:
             raise DuplicateSubscriberIdentifier("RPC identifier '{}'".format(identifier))
         self._rpc_subscribers[identifier] = subscriber
+        return identifier
 
     def remove_rpc_subscriber(self, identifier):
         try:

--- a/test/test_communications.py
+++ b/test/test_communications.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`kiwipy.communications` module."""
+from __future__ import absolute_import
+import pytest
+
+from kiwipy import CommunicatorHelper
+
+
+class Subscriber:
+    """Test class that mocks a subscriber."""
+
+
+class Communicator(CommunicatorHelper):
+
+    def task_send(self, task, no_reply=False):
+        pass
+
+    def rpc_send(self, recipient_id, msg):
+        pass
+
+    def broadcast_send(self, body, sender=None, subject=None, correlation_id=None):
+        pass
+
+
+@pytest.fixture
+def communicator():
+    """Return an instance of `Communicator`."""
+    return Communicator()
+
+
+@pytest.fixture
+def subscriber():
+    """Return an instance of `Subscriber`."""
+    return Subscriber()
+
+
+def test_add_rpc_subscriber(communicator, subscriber):
+    """Test the `Communicator.add_rpc_subscriber` method."""
+    assert communicator.add_rpc_subscriber(subscriber) is not None
+
+    identifier = 'identifier'
+    assert communicator.add_rpc_subscriber(subscriber, identifier) == identifier
+
+
+def test_remove_rpc_subscriber(communicator, subscriber):
+    """Test the `Communicator.remove_rpc_subscriber` method."""
+    identifier = communicator.add_rpc_subscriber(subscriber)
+    communicator.remove_rpc_subscriber(identifier)
+
+
+def test_add_broadcast_subscriber(communicator, subscriber):
+    """Test the `Communicator.add_broadcast_subscriber` method."""
+    assert communicator.add_broadcast_subscriber(subscriber) is not None
+
+    identifier = 'identifier'
+    assert communicator.add_broadcast_subscriber(subscriber, identifier) == identifier
+
+
+def test_remove_broadcast_subscriber(communicator, subscriber):
+    """Test the `Communicator.remove_broadcast_subscriber` method."""
+    identifier = communicator.add_broadcast_subscriber(subscriber)
+    communicator.remove_broadcast_subscriber(identifier)
+
+
+def test_add_task_subscriber(communicator, subscriber):
+    """Test the `Communicator.add_task_subscriber` method."""
+    assert communicator.add_task_subscriber(subscriber) is None
+
+
+def test_remove_task_subscriber(communicator, subscriber):
+    """Test the `Communicator.remove_task_subscriber` method."""
+    communicator.add_task_subscriber(subscriber)
+    communicator.remove_task_subscriber(subscriber)


### PR DESCRIPTION
Fixes #61 

The spec of the `Communicator` abstract class stipulates that the
`add_rpc_subscriber` should always return the identifier, even if an
explicit one was passed in. The `CommunicatorHelper` violated this
specification but went unnoticed since it was not tested.