### PR TITLE
Added note to documentation on how to contribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,11 @@ Versioning
 
 This software follows `Semantic Versioning`_
 
+Contributing
+============
 
+Want a new feature? Found a bug? Want to contribute more documentation or a translation perhaps?
+
+Help is always welcome, get started with the `contributing guide <https://github.com/aiidateam/kiwipy/wiki/Contributing>`__.
 
 .. _Semantic Versioning: http://semver.org/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,6 +60,13 @@ Getting Started
 * The design concepts behind kiwiPy can be found in `concepts`_ section
 * Finally check out the complete `API documentation`_
 
+.. admonition:: Development Contributions
+   :class: note
+
+   Want a new feature? Found a bug? Want to contribute more documentation or a translation perhaps?
+   Help is always welcome, get started with the `contributing guide <https://github.com/aiidateam/kiwipy/wiki/Contributing>`__.
+
+
 
 Table Of Contents
 +++++++++++++++++


### PR DESCRIPTION
Added box on index page of docs pointing readers to the wiki which explains how they can contribute to kiwiPy.   Also added to README as served by github and pypi (amongst others).

Fixes #65 .