### PR TITLE
Fix a cyclic-import in `kiwipy.rmq.utils`

### DIFF
--- a/kiwipy/rmq/utils.py
+++ b/kiwipy/rmq/utils.py
@@ -7,7 +7,7 @@ import os
 import socket
 import traceback
 
-import kiwipy
+from kiwipy import exceptions
 
 __all__ = ()
 
@@ -79,7 +79,7 @@ def response_to_future(response, future=None):
     if CANCELLED_KEY in response:
         future.cancel()
     elif EXCEPTION_KEY in response:
-        future.set_exception(kiwipy.RemoteException(response[EXCEPTION_KEY]))
+        future.set_exception(exceptions.RemoteException(response[EXCEPTION_KEY]))
     elif RESULT_KEY in response:
         future.set_result(response[RESULT_KEY])
     elif PENDING_KEY in response:


### PR DESCRIPTION
It was importing the entire `kiwipy` package just to access the
`RemoteException` class. This has been moved within the function scope
where it is used to prevent the cyclic dependency.