### PR TITLE
Dependencies: update requirement `pytest-asyncio~=0.12`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             'coverage',
             'pytest-cov',
             'pytest~=5.4',
-            'pytest-asyncio<=0.10.0',
+            'pytest-asyncio~=0.12',
             'pytest-notebook',
             'pytest-benchmark',
             'pika',


### PR DESCRIPTION
Fixes #47 

Version `0.11.0` of `pytest-asyncio` introduced a change that breaks our
test because the `event_loop` fixture will no longer be run as fast as
possible causing tests that use it to start a different event loop. This
would throw an error saying that the future was attached to a different
event loop. This is fixed in `pytest-asyncio==0.12.0`.