### PR TITLE
Dependencies: add support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
                 sudo apt install pandoc
 
         -   name: Set up Python
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: 3.8
 
@@ -57,7 +57,7 @@ jobs:
                     pip-pre-commit-
 
         -   name: Set up Python
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: 3.8
 
@@ -75,7 +75,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8]
+                python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
         services:
             rabbitmq:
@@ -96,7 +96,7 @@ jobs:
                     pip-${{ matrix.python-version }}-tests
 
         -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: ${{ matrix.python-version }}
 

--- a/kiwipy/rmq/messages.py
+++ b/kiwipy/rmq/messages.py
@@ -256,7 +256,7 @@ class BasePublisherWithReplyQueue:
                 except Exception:  # pylint: disable=broad-except
                     pass
 
-    def _on_channel_close(self, _closing_future):
+    def _on_channel_close(self, _closing_future, *_, **__):
         """ Reset all channel specific members """
         if self._confirm_deliveries:
             self._num_published = 0

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='communication messaging rpc broadcast',
     install_requires=['shortuuid', 'async_generator', 'pytray>=0.2.2, <0.4.0', 'deprecation'],


### PR DESCRIPTION
Fixes #085

The change to `BasePublisherWithReplyQueue._on_channel_close`
signature is not related to Python 3.9 but a change in the dependencies
that can call this callback with additional arguments or keyword
arguments which would raise since the signature doesn't alloq it.