### PR TITLE
Drop support for Python 3.5 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
                 sudo apt install pandoc
 
         -   name: Set up Python
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: 3.8
 
@@ -57,7 +57,7 @@ jobs:
                     pip-pre-commit-
 
         -   name: Set up Python
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: 3.8
 
@@ -75,7 +75,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8]
+                python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
         services:
             rabbitmq:
@@ -96,7 +96,7 @@ jobs:
                     pip-${{ matrix.python-version }}-tests
 
         -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+                python-version: [3.6, 3.7, 3.8, 3.9]
 
         services:
             rabbitmq:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,7 +53,7 @@ Features
 * Generic communicator interface with native support for RabbitMQ
 * Supports task queues, broadcasts and RPC
 * Support for both thread and coroutine based communication
-* Python 3.5+ compatible.
+* Python 3.6+ compatible.
 
 
 Getting Started

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,7 +8,7 @@ Installation
 Python
 ------
 
-KiwiPy supports Python versions 3.5 and above, however, the minimum required patch versions are 3.5.4 and 3.6.2 for Python 3.5 and 3.6, respectively.
+KiwiPy supports Python versions 3.6 and above, however, the minimum required patch version is 3.6.2.
 All newer versions are supported.
 
 RabbitMQ

--- a/kiwipy/filters.py
+++ b/kiwipy/filters.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
 import typing
-try:
-    # py3.5 compatibility, see, e.g.:
-    # https://stackoverflow.com/questions/6102019/type-of-compiled-regex-object-in-python
-    import typing.re
-    RePattern = typing.re.Pattern  # pylint: disable=invalid-name
-except ImportError:
-    RePattern = typing.Pattern  # pylint: disable=invalid-name
 
 __all__ = ('BroadcastFilter',)
 
@@ -49,7 +42,7 @@ class BroadcastFilter:
     def _ensure_filter(cls, filter_value):
         if isinstance(filter_value, str):
             return re.compile(filter_value.replace('.', '[.]').replace('*', '.*')).match
-        if isinstance(filter_value, RePattern):
+        if isinstance(filter_value, typing.Pattern):  # pylint: disable=isinstance-second-argument-not-valid-type
             return filter_value.match
 
         return lambda val: val == filter_value

--- a/kiwipy/rmq/messages.py
+++ b/kiwipy/rmq/messages.py
@@ -256,7 +256,7 @@ class BasePublisherWithReplyQueue:
                 except Exception:  # pylint: disable=broad-except
                     pass
 
-    def _on_channel_close(self, _closing_future):
+    def _on_channel_close(self, _closing_future, *_, **__):
         """ Reset all channel specific members """
         if self._confirm_deliveries:
             self._num_published = 0

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='communication messaging rpc broadcast',
     install_requires=['shortuuid', 'async_generator', 'pytray>=0.2.2, <0.4.0', 'deprecation'],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -30,7 +29,7 @@ setup(
     ],
     keywords='communication messaging rpc broadcast',
     install_requires=['shortuuid', 'async_generator', 'pytray>=0.2.2, <0.4.0', 'deprecation'],
-    python_requires='>=3.5.4',
+    python_requires='>=3.6.2',
     extras_require={
         'docs': [
             'docutils==0.14',


### PR DESCRIPTION
Fixes #86

Python 3.5 is EOL as of September 13 2020.