### PR TITLE
Replace old format string interpolation with f-strings 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,21 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
 
+-   repo: https://github.com/ikamensh/flynt/
+    rev: '0.55'
+    hooks:
+    -   id: flynt
+        args: [
+            '--line-length=120',
+            '--fail-on-change',
+        ]
+
+-   repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.30.0
+    hooks:
+    -   id: yapf
+        types: [python]
+
 -   repo: https://github.com/PyCQA/pylint
     rev: pylint-2.5.2
     hooks:
@@ -29,9 +44,3 @@ repos:
             '--disable=too-many-instance-attributes',
         ]
         exclude: *exclude_files
-
--   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.30.0
-    hooks:
-    -   id: yapf
-        types: [python]

--- a/docs/source/examples/kiwipy/emit_log_topic.py
+++ b/docs/source/examples/kiwipy/emit_log_topic.py
@@ -6,4 +6,4 @@ message = ' '.join(sys.argv[2:]) or 'Hello World!'
 with kiwipy.connect('amqp://localhost') as comm:
     subject = sys.argv[1] if len(sys.argv) > 2 else 'anonymous.info'
     comm.broadcast_send(message, subject=subject)
-    print(' [x] Sent %r:%r' % (subject, message))
+    print(f' [x] Sent {subject!r}:{message!r}')

--- a/docs/source/examples/kiwipy/new_task.py
+++ b/docs/source/examples/kiwipy/new_task.py
@@ -6,4 +6,4 @@ message = ' '.join(sys.argv[1:]) or 'Hello World!'
 with kiwipy.connect('amqp://localhost') as comm:
     queue = comm.task_queue('task_queue')  # Durable by default
     queue.task_send(message)
-    print(' [x] Sent %r' % message)
+    print(f' [x] Sent {message!r}')

--- a/docs/source/examples/kiwipy/receive_logs_topic.py
+++ b/docs/source/examples/kiwipy/receive_logs_topic.py
@@ -4,13 +4,13 @@ import threading
 
 
 def callback(_comm, body, _sender, subject, _msg_id):
-    print(' [x] %r:%r' % (subject, body))
+    print(f' [x] {subject!r}:{body!r}')
 
 
 with kiwipy.connect('amqp://localhost') as comm:
     binding_keys = sys.argv[1:]
     if not binding_keys:
-        sys.stderr.write('Usage: %s [binding_key]...\n' % sys.argv[0])
+        sys.stderr.write(f'Usage: {sys.argv[0]} [binding_key]...\n')
         sys.exit(1)
 
     for binding_key in binding_keys:

--- a/docs/source/examples/kiwipy/rpc_client.py
+++ b/docs/source/examples/kiwipy/rpc_client.py
@@ -3,4 +3,4 @@ import kiwipy
 with kiwipy.connect('amqp://localhost') as comm:
     print(' [x] Requesting fib(30)')
     response = comm.rpc_send('rpc_queue', 30).result()
-    print(' [.] Got %r' % response)
+    print(f' [.] Got {response!r}')

--- a/docs/source/examples/kiwipy/rpc_server.py
+++ b/docs/source/examples/kiwipy/rpc_server.py
@@ -14,7 +14,7 @@ def fib(n):
 def on_request(_comm, body):
     n = int(body)
 
-    print(' [.] fib(%s)' % n)
+    print(f' [.] fib({n})')
     return fib(n)
 
 

--- a/docs/source/examples/kiwipy/worker.py
+++ b/docs/source/examples/kiwipy/worker.py
@@ -4,7 +4,7 @@ import time
 
 
 def callback(_comm, body):
-    print(' [x] Received %r' % body)
+    print(f' [x] Received {body!r}')
     time.sleep(body.count('.'))
     print(' [x] Done')
     return True

--- a/docs/source/examples/pika/emit_log_topic.py
+++ b/docs/source/examples/pika/emit_log_topic.py
@@ -9,5 +9,5 @@ channel.exchange_declare(exchange='topic_logs', exchange_type='topic')
 routing_key = sys.argv[1] if len(sys.argv) > 2 else 'anonymous.info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(exchange='topic_logs', routing_key=routing_key, body=message)
-print(' [x] Sent %r:%r' % (routing_key, message))
+print(f' [x] Sent {routing_key!r}:{message!r}')
 connection.close()

--- a/docs/source/examples/pika/new_task.py
+++ b/docs/source/examples/pika/new_task.py
@@ -15,5 +15,5 @@ channel.basic_publish(
         delivery_mode=2,  # make message persistent
     )
 )
-print(' [x] Sent %r' % message)
+print(f' [x] Sent {message!r}')
 connection.close()

--- a/docs/source/examples/pika/receive_logs_topic.py
+++ b/docs/source/examples/pika/receive_logs_topic.py
@@ -11,7 +11,7 @@ queue_name = result.method.queue
 
 binding_keys = sys.argv[1:]
 if not binding_keys:
-    sys.stderr.write('Usage: %s [binding_key]...\n' % sys.argv[0])
+    sys.stderr.write(f'Usage: {sys.argv[0]} [binding_key]...\n')
     sys.exit(1)
 
 for binding_key in binding_keys:
@@ -21,7 +21,7 @@ print(' [*] Waiting for logs. To exit press CTRL+C')
 
 
 def callback(ch, method, properties, body):
-    print(' [x] %r:%r' % (method.routing_key, body))
+    print(f' [x] {method.routing_key!r}:{body!r}')
 
 
 channel.basic_consume(queue=queue_name, on_message_callback=callback, auto_ack=True)

--- a/docs/source/examples/pika/rpc_client.py
+++ b/docs/source/examples/pika/rpc_client.py
@@ -39,4 +39,4 @@ fibonacci_rpc = FibonacciRpcClient()
 
 print(' [x] Requesting fib(30)')
 response = fibonacci_rpc.call(30)
-print(' [.] Got %r' % response)
+print(f' [.] Got {response!r}')

--- a/docs/source/examples/pika/rpc_server.py
+++ b/docs/source/examples/pika/rpc_server.py
@@ -19,7 +19,7 @@ def fib(n):
 def on_request(ch, method, props, body):
     n = int(body)
 
-    print(' [.] fib(%s)' % n)
+    print(f' [.] fib({n})')
     response = fib(n)
 
     ch.basic_publish(exchange='',

--- a/docs/source/examples/pika/worker.py
+++ b/docs/source/examples/pika/worker.py
@@ -9,7 +9,7 @@ print(' [*] Waiting for messages. To exit press CTRL+C')
 
 
 def callback(ch, method, properties, body):
-    print(' [x] Received %r' % body)
+    print(f' [x] Received {body!r}')
     time.sleep(body.count(b'.'))
     print(' [x] Done')
     ch.basic_ack(delivery_tag=method.delivery_tag)

--- a/examples/rmq_broadcast_server.py
+++ b/examples/rmq_broadcast_server.py
@@ -6,12 +6,12 @@ import kiwipy
 
 def on_broadcast_send(_comm, body, sender, subject, __):
     print(' [x] listening on_broadcast_send:')
-    print(' body: {}, sender {}, subject {}\n'.format(body, sender, subject))
+    print(f' body: {body}, sender {sender}, subject {subject}\n')
 
 
 def on_broadcast_filter(_comm, body, sender=None, subject=None, __=None):
     print(' [x] listening on_broadcast_filter:')
-    print(' body: {}, sender {}, subject {}\n'.format(body, sender, subject))
+    print(f' body: {body}, sender {sender}, subject {subject}\n')
 
 
 if __name__ == '__main__':

--- a/examples/rmq_rpc_client.py
+++ b/examples/rmq_rpc_client.py
@@ -7,9 +7,9 @@ with kiwipy.connect('amqp://127.0.0.1') as comm:
     # Send an RPC message with identifier 'fib'
     print(' [x] Requesting fib(30)')
     response = comm.rpc_send('fib', 30).result()
-    print((' [.] Got %r' % response))
+    print(f' [.] Got {response!r}')
 
     # Send an RPC message with identifier 'fac'
     print(' [x] Requesting fac(3)')
     response = comm.rpc_send('fac', 3).result()
-    print((' [.] Got %r' % response))
+    print(f' [.] Got {response!r}')

--- a/examples/rmq_worker.py
+++ b/examples/rmq_worker.py
@@ -8,7 +8,7 @@ print(' [*] Waiting for messages. To exit press CTRL+C')
 
 
 def callback(_comm, task):
-    print((' [x] Received %r' % task))
+    print(f' [x] Received {task!r}')
     time.sleep(task.count('.'))
     print(' [x] Done')
     return task

--- a/kiwipy/communicate.py
+++ b/kiwipy/communicate.py
@@ -10,4 +10,4 @@ def connect(uri: str = DEFAULT_COMM_URI, **kwargs):
         from . import rmq  # Avoid circular ref: pylint: disable=import-outside-toplevel
         return rmq.connect(connection_params=uri, **kwargs)
 
-    raise ValueError("Uknown communicator uri '{}'".format(uri))
+    raise ValueError(f"Uknown communicator uri '{uri}'")

--- a/kiwipy/communications.py
+++ b/kiwipy/communications.py
@@ -144,7 +144,7 @@ class CommunicatorHelper(Communicator):
         self._ensure_open()
         identifier = identifier or shortuuid.uuid()
         if identifier in self._rpc_subscribers:
-            raise exceptions.DuplicateSubscriberIdentifier("RPC identifier '{}'".format(identifier))
+            raise exceptions.DuplicateSubscriberIdentifier(f"RPC identifier '{identifier}'")
         self._rpc_subscribers[identifier] = subscriber
         return identifier
 
@@ -153,7 +153,7 @@ class CommunicatorHelper(Communicator):
         try:
             self._rpc_subscribers.pop(identifier)
         except KeyError:
-            raise ValueError("Unknown subscriber '{}'".format(identifier))
+            raise ValueError(f"Unknown subscriber '{identifier}'")
 
     def add_task_subscriber(self, subscriber, identifier=None):
         """
@@ -165,7 +165,7 @@ class CommunicatorHelper(Communicator):
         self._ensure_open()
         identifier = identifier or shortuuid.uuid()
         if identifier in self._rpc_subscribers:
-            raise exceptions.DuplicateSubscriberIdentifier("RPC identifier '{}'".format(identifier))
+            raise exceptions.DuplicateSubscriberIdentifier(f"RPC identifier '{identifier}'")
         self._task_subscribers[identifier] = subscriber
         return identifier
 
@@ -180,13 +180,13 @@ class CommunicatorHelper(Communicator):
         try:
             self._task_subscribers.pop(identifier)
         except KeyError:
-            raise ValueError("Unknown subscriber: '{}'".format(identifier))
+            raise ValueError(f"Unknown subscriber: '{identifier}'")
 
     def add_broadcast_subscriber(self, subscriber: BroadcastSubscriber, identifier=None) -> Any:
         self._ensure_open()
         identifier = identifier or shortuuid.uuid()
         if identifier in self._broadcast_subscribers:
-            raise exceptions.DuplicateSubscriberIdentifier("Broadcast identifier '{}'".format(identifier))
+            raise exceptions.DuplicateSubscriberIdentifier(f"Broadcast identifier '{identifier}'")
 
         self._broadcast_subscribers[identifier] = subscriber
         return identifier
@@ -196,7 +196,7 @@ class CommunicatorHelper(Communicator):
         try:
             del self._broadcast_subscribers[identifier]
         except KeyError:
-            raise ValueError("Broadcast subscriber '{}' unknown".format(identifier))
+            raise ValueError(f"Broadcast subscriber '{identifier}' unknown")
 
     def fire_task(self, msg, no_reply=False):
         self._ensure_open()
@@ -223,7 +223,7 @@ class CommunicatorHelper(Communicator):
         try:
             subscriber = self._rpc_subscribers[recipient_id]
         except KeyError:
-            raise exceptions.UnroutableError("Unknown rpc recipient '{}'".format(recipient_id))
+            raise exceptions.UnroutableError(f"Unknown rpc recipient '{recipient_id}'")
         else:
             future = futures.Future()
             try:

--- a/kiwipy/rmq/messages.py
+++ b/kiwipy/rmq/messages.py
@@ -166,7 +166,7 @@ class BasePublisherWithReplyQueue:
         self._exchange = await self._channel.declare_exchange(name=self.get_exchange_name(), **self._exchange_params)
 
         # Declare the reply queue
-        reply_queue_name = '{}-reply-{}'.format(self._exchange_name, str(uuid.uuid4()))
+        reply_queue_name = f'{self._exchange_name}-reply-{str(uuid.uuid4())}'
         self._reply_queue = await self._channel.declare_queue(
             name=reply_queue_name,
             exclusive=True,

--- a/kiwipy/rmq/tasks.py
+++ b/kiwipy/rmq/tasks.py
@@ -68,7 +68,7 @@ class RmqTaskSubscriber(messages.BaseConnectionWithExchange):
     async def add_task_subscriber(self, subscriber, identifier=None):
         identifier = identifier or shortuuid.uuid()
         if identifier in self._subscribers:
-            raise kiwipy.DuplicateSubscriberIdentifier("Task identifier '{}'".format(identifier))
+            raise kiwipy.DuplicateSubscriberIdentifier(f"Task identifier '{identifier}'")
 
         self._subscribers[identifier] = subscriber
         if self._consumer_tag is None:
@@ -80,7 +80,7 @@ class RmqTaskSubscriber(messages.BaseConnectionWithExchange):
         try:
             self._subscribers.pop(identifier)
         except KeyError:
-            raise ValueError("Unknown task subscriber '{}'".format(identifier))
+            raise ValueError(f"Unknown task subscriber '{identifier}'")
         if not self._subscribers:
             await self._task_queue.cancel(self._consumer_tag)
             self._consumer_tag = None
@@ -230,7 +230,7 @@ class RmqIncomingTask:
 
     def process(self) -> asyncio.Future:
         if self._state != TASK_PENDING:
-            raise asyncio.InvalidStateError('The task is {}'.format(self._state))
+            raise asyncio.InvalidStateError(f'The task is {self._state}')
 
         self._state = TASK_PROCESSING
         outcome = self._create_future()
@@ -243,7 +243,7 @@ class RmqIncomingTask:
 
     def requeue(self):
         if self._state not in [TASK_PENDING, TASK_PROCESSING]:
-            raise asyncio.InvalidStateError('The task is {}'.format(self._state))
+            raise asyncio.InvalidStateError(f'The task is {self._state}')
 
         self._state = TASK_REQUEUED
         self._message.nack(requeue=True)
@@ -254,7 +254,7 @@ class RmqIncomingTask:
         """Processing context.  The task should be done at the end otherwise it's assumed the
         caller doesn't want to process it and it's sent back to the queue"""
         if self._state != TASK_PENDING:
-            raise asyncio.InvalidStateError('The task is {}'.format(self._state))
+            raise asyncio.InvalidStateError(f'The task is {self._state}')
 
         self._state = TASK_PROCESSING
         outcome = self._subscriber.loop().create_future()

--- a/kiwipy/rmq/utils.py
+++ b/kiwipy/rmq/utils.py
@@ -45,7 +45,7 @@ def exception_response(exception: Exception, trace=None) -> dict:
     """
     msg = str(exception)
     if trace is not None:
-        msg += '\n{}'.format(''.join(traceback.format_tb(trace)[0]))
+        msg += f"\n{''.join(traceback.format_tb(trace)[0])}"
     return {EXCEPTION_KEY: msg}
 
 
@@ -85,7 +85,7 @@ def response_to_future(response, future=None):
     elif PENDING_KEY in response:
         future.set_result(asyncio.Future())
     else:
-        raise ValueError("Unknown response type '{}'".format(response))
+        raise ValueError(f"Unknown response type '{response}'")
 
     return future
 

--- a/test/rmq/test_rmq_thread_communicator.py
+++ b/test/rmq/test_rmq_thread_communicator.py
@@ -19,9 +19,9 @@ WAIT_TIMEOUT = 5.
 
 @pytest.fixture
 def thread_communicator():
-    message_exchange = '{}.{}'.format(__file__, shortuuid.uuid())
-    task_exchange = '{}.{}'.format(__file__, shortuuid.uuid())
-    task_queue = '{}.{}'.format(__file__, shortuuid.uuid())
+    message_exchange = f'{__file__}.{shortuuid.uuid()}'
+    task_exchange = f'{__file__}.{shortuuid.uuid()}'
+    task_queue = f'{__file__}.{shortuuid.uuid()}'
 
     communicator = rmq.RmqThreadCommunicator.connect(
         connection_params={'url': 'amqp://guest:guest@localhost:5672/'},
@@ -38,7 +38,7 @@ def thread_communicator():
 
 @pytest.fixture
 def thread_task_queue(thread_communicator: rmq.RmqThreadCommunicator):
-    task_queue_name = '{}.{}'.format(__file__, shortuuid.uuid())
+    task_queue_name = f'{__file__}.{shortuuid.uuid()}'
 
     task_queue = thread_communicator.task_queue(task_queue_name)
 
@@ -49,9 +49,9 @@ class TestRmqThreadCommunicator(CommunicatorTester, unittest.TestCase):
     """Use the standard tests cases to check the RMQ thread communicator"""
 
     def create_communicator(self):
-        message_exchange = '{}.message_exchange.{}'.format(self.__class__.__name__, shortuuid.uuid())
-        task_exchange = '{}.task_exchange.{}'.format(self.__class__.__name__, shortuuid.uuid())
-        task_queue = '{}.task_queue.{}'.format(self.__class__.__name__, shortuuid.uuid())
+        message_exchange = f'{self.__class__.__name__}.message_exchange.{shortuuid.uuid()}'
+        task_exchange = f'{self.__class__.__name__}.task_exchange.{shortuuid.uuid()}'
+        task_queue = f'{self.__class__.__name__}.task_queue.{shortuuid.uuid()}'
 
         return rmq.RmqThreadCommunicator.connect(
             connection_params={'url': 'amqp://guest:guest@localhost:5672/'},
@@ -92,7 +92,7 @@ class TestRmqThreadCommunicator(CommunicatorTester, unittest.TestCase):
             tasks.append(task)
             return result_future
 
-        task_queue = self.communicator.task_queue('test-queue-{}'.format(utils.rand_string(5)))
+        task_queue = self.communicator.task_queue(f'test-queue-{utils.rand_string(5)}')
 
         task_queue.add_task_subscriber(on_task)
         task_future = task_queue.task_send(TASK).result(timeout=self.WAIT_TIMEOUT)
@@ -110,7 +110,7 @@ class TestRmqThreadCommunicator(CommunicatorTester, unittest.TestCase):
         RESULT = 42
 
         # Create a new queue and sent the task
-        task_queue = self.communicator.task_queue('test-queue-{}'.format(utils.rand_string(5)))
+        task_queue = self.communicator.task_queue(f'test-queue-{utils.rand_string(5)}')
         task_future = task_queue.task_send(TASK)
 
         # Get the task and carry it out

--- a/test/rmq/test_tasks.py
+++ b/test/rmq/test_tasks.py
@@ -20,8 +20,8 @@ try:
     @pytest.fixture
     @async_generator
     async def task_publisher(connection: aio_pika.Connection):
-        exchange_name = '{}.{}'.format(__file__, uuid.uuid4())
-        task_queue_name = '{}.{}'.format(__file__, uuid.uuid4())
+        exchange_name = f'{__file__}.{uuid.uuid4()}'
+        task_queue_name = f'{__file__}.{uuid.uuid4()}'
 
         task_pub = rmq.RmqTaskPublisher(
             connection, queue_name=task_queue_name, exchange_name=exchange_name, testing_mode=True
@@ -33,8 +33,8 @@ try:
     @pytest.fixture
     @async_generator
     async def task_queue(connection: aio_pika.Connection):
-        exchange_name = '{}.{}'.format(__file__, uuid.uuid4())
-        task_queue_name = '{}.{}'.format(__file__, uuid.uuid4())
+        exchange_name = f'{__file__}.{uuid.uuid4()}'
+        task_queue_name = f'{__file__}.{uuid.uuid4()}'
 
         task_pub = rmq.RmqTaskQueue(
             connection, queue_name=task_queue_name, exchange_name=exchange_name, testing_mode=True

--- a/test/rmq/utils.py
+++ b/test/rmq/utils.py
@@ -11,9 +11,9 @@ from kiwipy import rmq
 async def new_communicator(connection_params, settings=None) -> kiwipy.rmq.RmqCommunicator:
     settings = settings or {}
 
-    message_exchange = '{}.{}'.format(__file__, shortuuid.uuid())
-    task_exchange = '{}.{}'.format(__file__, shortuuid.uuid())
-    task_queue = '{}.{}'.format(__file__, shortuuid.uuid())
+    message_exchange = f'{__file__}.{shortuuid.uuid()}'
+    task_exchange = f'{__file__}.{shortuuid.uuid()}'
+    task_queue = f'{__file__}.{shortuuid.uuid()}'
 
     return await rmq.async_connect(
         connection_params,


### PR DESCRIPTION
Fixes #87 

Since Python 3.5 is no longer supported, format string interpolations
can now be replaced by f-strings, introduced in Python 3.6, which are
more readable, require less characters and are more efficient.

~~Note that `pylint` issues a warning when using f-strings for log
messages, just as it does for format interpolated strings. The reasoning
is that this is slightly inefficient as the strings are always
interpolated even if the log is discarded, but also by not passing the
formatting parameters as arguments, the available metadata is reduced.
I feel these inefficiencies are premature optimizations as they are
really minimal and don't weigh up against the improved readability and
maintainability of using f-strings.~~

The majority of the conversions were done automatically with the linting
tool `flynt` which is also added as a pre-commit hook. It is added
before the `yapf` step because since `flynt` will touch formatting,
`yapf` will then get a chance to check it.