### PR TITLE
👌 IMPROVE: close loop on RmqThreadCommunicator.close

### DIFF
--- a/kiwipy/rmq/threadcomms.py
+++ b/kiwipy/rmq/threadcomms.py
@@ -171,6 +171,7 @@ class RmqThreadCommunicator(kiwipy.Communicator):
 
         self._loop_scheduler.await_(self._communicator.disconnect())
         self._loop_scheduler.close()
+        self._loop.close()
 
         # Clean up
         del self._communicator


### PR DESCRIPTION
The `RmqThreadCommunicator` creates a new_event_loop on initialising, and so on close it should also close it.

@muhrin can you think of any reason why this would be an issue?