### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         rabbitmq: [latest]
         include:
         - python-version: 3.8
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: github.repository == 'aiidateam/kiwipy'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
             file: ./coverage.xml
             name: kiwipy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -250,7 +250,7 @@ def run_apidoc(app):
 
 autodoc_default_options = {
     # these all derive from concurrent.futures, whose docstrings are in the wrong format
-    'exclude-members': 'CancelledError,wait,as_completed,Future'
+    'exclude-members': 'CancelledError,wait,as_completed,Future,TimeoutError'
 }
 
 

--- a/kiwipy/communications.py
+++ b/kiwipy/communications.py
@@ -120,7 +120,7 @@ class Communicator:
 
 class CommunicatorHelper(Communicator):
     # Have to disable this linter because this class remains abstract and it is
-    # just used by calsses that will themselves be concrete
+    # just used by classes that will themselves be concrete
     # pylint: disable=abstract-method
 
     def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     keywords='communication messaging rpc broadcast',
     install_requires=['shortuuid', 'async_generator', 'pytray>=0.2.2, <0.4.0', 'deprecation'],
-    python_requires='>=3.6.2',
+    python_requires='>=3.7',
     extras_require={
         'docs': [
             'docutils==0.14',
@@ -43,9 +43,10 @@ setup(
         'rmq': ['aio-pika', 'pyyaml~=5.1'],
         'tests': [
             'coverage',
+            'ipykernel',
             'pytest-cov',
             'pytest~=5.4',
-            'pytest-asyncio~=0.12',
+            'pytest-asyncio~=0.12,<0.17',
             'pytest-notebook>=0.7',
             'pytest-benchmark',
             'pika',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             'pytest-cov',
             'pytest~=5.4',
             'pytest-asyncio~=0.12',
-            'pytest-notebook',
+            'pytest-notebook>=0.7',
             'pytest-benchmark',
             'pika',
             'msgpack',

--- a/test/rmq/conftest.py
+++ b/test/rmq/conftest.py
@@ -10,7 +10,6 @@ DEFAULT_RMQ_URI = 'amqp://guest:guest@127.0.0.1:5672/'
 
 try:
     import aio_pika
-    from async_generator import yield_, async_generator
 
     # pylint: disable=redefined-outer-name
 
@@ -19,17 +18,15 @@ try:
         return {'url': os.environ.get(ENV_KIWI_RMQ_URI, DEFAULT_RMQ_URI)}
 
     @pytest.fixture
-    @async_generator
     async def connection(connection_params: dict):
         conn = await aio_pika.connect_robust(**connection_params)
-        await yield_(conn)
+        yield conn
         await conn.close()
 
     @pytest.fixture
-    @async_generator
     async def communicator(connection_params):
         communicator = await utils.new_communicator(connection_params)
-        await yield_(communicator)
+        yield communicator
         await communicator.disconnect()
 
 except ImportError:

--- a/test/rmq/test_rmq_thread_communicator.py
+++ b/test/rmq/test_rmq_thread_communicator.py
@@ -265,5 +265,5 @@ def test_jupyter_notebook():
     # Express the path in a way that will work no matter where the tests are being ran and convert
     # to str as py35 doesn't support Paths being passed to open()
     my_dir = pathlib.Path(__file__).parent
-    with open(str(my_dir / pathlib.Path('notebooks/communicator.ipynb'))) as handle:
+    with open(my_dir / pathlib.Path('notebooks/communicator.ipynb')) as handle:
         fixture.check(handle)

--- a/test/rmq/test_tasks.py
+++ b/test/rmq/test_tasks.py
@@ -11,14 +11,12 @@ WAIT_TIMEOUT = 5.
 try:
     import asyncio
 
-    from async_generator import yield_, async_generator
     import aio_pika
     import aio_pika.exceptions
     from kiwipy import rmq
     import kiwipy.rmq
 
     @pytest.fixture
-    @async_generator
     async def task_publisher(connection: aio_pika.Connection):
         exchange_name = f'{__file__}.{uuid.uuid4()}'
         task_queue_name = f'{__file__}.{uuid.uuid4()}'
@@ -27,11 +25,10 @@ try:
             connection, queue_name=task_queue_name, exchange_name=exchange_name, testing_mode=True
         )
         await task_pub.connect()
-        await yield_(task_pub)
+        yield task_pub
         await task_pub.disconnect()
 
     @pytest.fixture
-    @async_generator
     async def task_queue(connection: aio_pika.Connection):
         exchange_name = f'{__file__}.{uuid.uuid4()}'
         task_queue_name = f'{__file__}.{uuid.uuid4()}'
@@ -40,7 +37,7 @@ try:
             connection, queue_name=task_queue_name, exchange_name=exchange_name, testing_mode=True
         )
         await task_pub.connect()
-        await yield_(task_pub)
+        yield task_pub
         await task_pub.disconnect()
 
 except ImportError:

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist = py37
 [testenv]
 usedevelop = true
 
-[testenv:py{36,37,38,39}]
+[testenv:py{37,38,39}]
 description = Run the unit tests
 extras =
     rmq


### PR DESCRIPTION
Fixed tests by removing async_generator
    
This was being used for compatibility with py3.5 but we are not
supporting this anymore so we can rely on the build-in support for async
yields and test-asyncio for fixtures.


@chrisjsewell do you understand why the out jupyter notebook test fails?  I don't understand the error message at all...