### PR TITLE
Reinstanting RmqThreadCommunicator tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,9 @@ keywords = ['ommunication', 'messaging', 'rpc', 'broadcast']
 requires-python = '>=3.7'
 dependencies = [
     'aio-pika~=8.0',
-    'async_generator',
     'deprecation',
     'nest_asyncio~=1.5,>=1.5.1',
-    'pytray>=0.2.2,<0.4.0',
+    'pytray>=0.3.4,<0.4.0',
     'pyyaml~=5.4',
 ]
 

--- a/src/kiwipy/rmq/tasks.py
+++ b/src/kiwipy/rmq/tasks.py
@@ -236,7 +236,7 @@ class RmqIncomingTask:
         outcome = self._loop.create_future()
         # Rely on the done callback to signal the end of processing
         outcome.add_done_callback(self._on_task_done)
-        # Or the user let's the future get destroyed
+        # Or the user lets the future get destroyed
         self._outcome_ref = weakref.ref(outcome, self._outcome_destroyed)
 
         return outcome
@@ -252,7 +252,7 @@ class RmqIncomingTask:
     @asynccontextmanager
     async def processing(self):
         """Processing context.  The task should be done at the end otherwise it's assumed the
-        caller doesn't want to process it and it's sent back to the queue"""
+        caller doesn't want to process it, and it's sent back to the queue"""
         if self._state != TASK_PENDING:
             raise asyncio.InvalidStateError(f'The task is {self._state}')
 

--- a/src/kiwipy/rmq/threadcomms.py
+++ b/src/kiwipy/rmq/threadcomms.py
@@ -351,8 +351,10 @@ class RmqThreadIncomingTask:
         return aiothreads.aio_future_to_thread(self._task.process())
 
     def requeue(self):
-        """Calling this will cause the task to be requeued.  This call is blocking and by the time function returns
-        the task will be back in the queue"""
+        """Requeue the task.
+
+        This call is blocking and by the time function returns the task will be back in the queue.
+        """
         self._loop_scheduler.await_(self._task.requeue())
 
     @contextmanager

--- a/src/kiwipy/rmq/threadcomms.py
+++ b/src/kiwipy/rmq/threadcomms.py
@@ -351,7 +351,7 @@ class RmqThreadIncomingTask:
         return aiothreads.aio_future_to_thread(self._task.process())
 
     def requeue(self):
-        self._task.requeue()
+        self._loop_scheduler.await_(self._task.requeue())
 
     @contextmanager
     def processing(self):

--- a/src/kiwipy/rmq/threadcomms.py
+++ b/src/kiwipy/rmq/threadcomms.py
@@ -351,11 +351,13 @@ class RmqThreadIncomingTask:
         return aiothreads.aio_future_to_thread(self._task.process())
 
     def requeue(self):
+        """Calling this will cause the task to be requeued.  This call is blocking and by the time function returns
+        the task will be back in the queue"""
         self._loop_scheduler.await_(self._task.requeue())
 
     @contextmanager
     def processing(self):
-        with self._loop_scheduler.ctx(self._task.processing()) as outcome:
+        with self._loop_scheduler.async_ctx(self._task.processing()) as outcome:
             yield outcome
 
 

--- a/test/rmq/bench/support.py
+++ b/test/rmq/bench/support.py
@@ -32,10 +32,10 @@ def get_tasks(num_tasks, queue: rmq.RmqThreadTaskQueue):
             queue.remove_task_subscriber(identifier)
 
 
-async def clear_all_tasks(queue: rmq.RmqThreadTaskQueue):
+def clear_all_tasks(queue: rmq.RmqThreadTaskQueue):
     """Just go through all tasks picking them up so the queue is cleared"""
     for task in queue:
-        async with task.processing() as outcome:
+        with task.processing() as outcome:
             outcome.set_result(True)
 
 

--- a/test/rmq/test_coroutine_communicator.py
+++ b/test/rmq/test_coroutine_communicator.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import asyncio
+import gc
 
 import pytest
+import shortuuid
 
 import kiwipy
 import kiwipy.rmq
@@ -208,3 +210,36 @@ def test_server_properties(communicator: kiwipy.rmq.RmqCommunicator):
     assert props['product'] == 'RabbitMQ'
     assert 'version' in props
     assert props['platform'].startswith('Erlang')
+
+
+@pytest.mark.asyncio
+async def test_queue_task_forget(communicator: kiwipy.rmq.RmqCommunicator):
+    """
+    Check what happens when we forget to process a task we said we would
+    WARNING: This test mail fail when running with a debugger as it relies on the 'outcome'
+    reference count dropping to zero but the debugger may be preventing this.
+    """
+    task_queue_name = f'{__file__}.{shortuuid.uuid()}'
+    task_queue = await communicator.task_queue(task_queue_name)
+
+    outcomes = [await task_queue.task_send(1)]
+
+    # Get the first task and say that we will process it
+    outcome = None
+    async with task_queue.next_task() as task:
+        outcome = task.process()
+
+    with pytest.raises(kiwipy.exceptions.QueueEmpty):
+        async with task_queue.next_task():
+            pass
+
+    # Now let's 'forget' i.e. lose the outcome
+    del outcome
+    gc.collect()
+
+    # Now the task should be back in the queue
+    async with task_queue.next_task() as task:
+        task.process().set_result(10)
+
+    await asyncio.wait(outcomes)
+    assert outcomes[0].result() == 10

--- a/test/rmq/test_coroutine_communicator.py
+++ b/test/rmq/test_coroutine_communicator.py
@@ -216,7 +216,7 @@ def test_server_properties(communicator: kiwipy.rmq.RmqCommunicator):
 async def test_queue_task_forget(communicator: kiwipy.rmq.RmqCommunicator):
     """
     Check what happens when we forget to process a task we said we would
-    WARNING: This test mail fail when running with a debugger as it relies on the 'outcome'
+    WARNING: This test may fail when running with a debugger as it relies on the 'outcome'
     reference count dropping to zero but the debugger may be preventing this.
     """
     task_queue_name = f'{__file__}.{shortuuid.uuid()}'

--- a/test/rmq/test_rmq_thread_communicator.py
+++ b/test/rmq/test_rmq_thread_communicator.py
@@ -131,9 +131,6 @@ def test_queue_get_next(thread_task_queue: rmq.RmqThreadTaskQueue):
         with task.processing() as outcome:
             assert task.body == 'Hello!'
             outcome.set_result('Goodbye')
-            print('test_queue_get_next leaving processing() ctx')
-        print('test_queue_get_next leaving next_task() ctx')
-    print('test_queue_get_next getting result.result()')
     assert result.result() == 'Goodbye'
 
 
@@ -186,7 +183,7 @@ def test_queue_iter_not_process(thread_task_queue: rmq.RmqThreadTaskQueue):
 def test_queue_task_forget(thread_task_queue: rmq.RmqThreadTaskQueue):
     """
     Check what happens when we forget to process a task we said we would
-    WARNING: This test mail fail when running with a debugger as it relies on the 'outcome'
+    WARNING: This test may fail when running with a debugger as it relies on the 'outcome'
     reference count dropping to zero but the debugger may be preventing this.
     """
     outcomes = [thread_task_queue.task_send(1)]

--- a/test/rmq/test_rmq_thread_communicator.py
+++ b/test/rmq/test_rmq_thread_communicator.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+"""
+WARNING: This file should not contain any coroutines code (i.e. no use of async/await) as the intended
+function of RmqThreadCommunicator is that users should be completely shielded from the asyncio code.
+"""
 # pylint: disable=invalid-name, redefined-outer-name
 import concurrent.futures
 import pathlib
@@ -103,7 +107,7 @@ class TestRmqThreadCommunicator(CommunicatorTester, unittest.TestCase):
         self.assertEqual(TASK, tasks[0])
         self.assertEqual(RESULT, result)
 
-    async def test_task_queue_next(self):
+    def test_task_queue_next(self):
         """Test creating a custom task queue"""
         TASK = 'The meaning?'
         RESULT = 42
@@ -114,24 +118,24 @@ class TestRmqThreadCommunicator(CommunicatorTester, unittest.TestCase):
 
         # Get the task and carry it out
         with task_queue.next_task() as task:
-            await task.process().set_result(RESULT)
+            task.process().set_result(RESULT)
 
         # Now wait for the result
         result = task_future.result(timeout=self.WAIT_TIMEOUT)
         self.assertEqual(RESULT, result)
 
 
-async def test_queue_get_next(thread_task_queue: rmq.RmqThreadTaskQueue):
+def test_queue_get_next(thread_task_queue: rmq.RmqThreadTaskQueue):
     """Test getting the next task from the queue"""
     result = thread_task_queue.task_send('Hello!')
     with thread_task_queue.next_task(timeout=1.) as task:
-        async with task.processing() as outcome:
+        with task.processing() as outcome:
             assert task.body == 'Hello!'
             outcome.set_result('Goodbye')
     assert result.result() == 'Goodbye'
 
 
-async def test_queue_iter(thread_task_queue: rmq.RmqThreadTaskQueue):
+def test_queue_iter(thread_task_queue: rmq.RmqThreadTaskQueue):
     """Test iterating through a task queue"""
     results = []
 
@@ -140,7 +144,7 @@ async def test_queue_iter(thread_task_queue: rmq.RmqThreadTaskQueue):
         results.append(thread_task_queue.task_send(i))
 
     for task in thread_task_queue:
-        async with task.processing() as outcome:
+        with task.processing() as outcome:
             outcome.set_result(task.body * 10)
 
     concurrent.futures.wait(results)
@@ -151,7 +155,7 @@ async def test_queue_iter(thread_task_queue: rmq.RmqThreadTaskQueue):
         assert False, "Shouldn't get here"
 
 
-async def test_queue_iter_not_process(thread_task_queue: rmq.RmqThreadTaskQueue):
+def test_queue_iter_not_process(thread_task_queue: rmq.RmqThreadTaskQueue):
     """Check what happens when we iterate a queue but don't process all tasks"""
     outcomes = []
 
@@ -162,7 +166,7 @@ async def test_queue_iter_not_process(thread_task_queue: rmq.RmqThreadTaskQueue)
     # Now let's see what happens when we have tasks but don't process some of them
     for task in thread_task_queue:
         if task.body < 5:
-            await task.process().set_result(task.body * 10)
+            task.process().set_result(task.body * 10)
 
     concurrent.futures.wait(outcomes[:5])
     for i, outcome in enumerate(outcomes[:5]):
@@ -170,14 +174,14 @@ async def test_queue_iter_not_process(thread_task_queue: rmq.RmqThreadTaskQueue)
 
     # Now, to through and process the rest
     for task in thread_task_queue:
-        await task.process().set_result(task.body * 10)
+        task.process().set_result(task.body * 10)
 
     concurrent.futures.wait(outcomes)
     for i, outcome in enumerate(outcomes):
         assert outcome.result() == i * 10
 
 
-async def test_queue_task_forget(thread_task_queue: rmq.RmqThreadTaskQueue):
+def test_queue_task_forget(thread_task_queue: rmq.RmqThreadTaskQueue):
     """
     Check what happens when we forget to process a task we said we would
     WARNING: This test mail fail when running with a debugger as it relies on the 'outcome'
@@ -188,7 +192,7 @@ async def test_queue_task_forget(thread_task_queue: rmq.RmqThreadTaskQueue):
     # Get the first task and say that we will process it
     outcome = None
     with thread_task_queue.next_task() as task:
-        outcome = await task.process()
+        outcome = task.process()
 
     with pytest.raises(kiwipy.exceptions.QueueEmpty):
         with thread_task_queue.next_task():
@@ -199,7 +203,7 @@ async def test_queue_task_forget(thread_task_queue: rmq.RmqThreadTaskQueue):
 
     # Now the task should be back in the queue
     with thread_task_queue.next_task() as task:
-        await task.process().set_result(10)
+        task.process().set_result(10)
 
     concurrent.futures.wait(outcomes)
     assert outcomes[0].result() == 10
@@ -211,14 +215,14 @@ def test_empty_queue(thread_task_queue: rmq.RmqThreadTaskQueue):
             pass
 
 
-async def test_task_processing_exception(thread_task_queue: rmq.RmqThreadTaskQueue):
+def test_task_processing_exception(thread_task_queue: rmq.RmqThreadTaskQueue):
     """Check that if there is an exception processing a task that it is removed from the queue"""
     task_future = thread_task_queue.task_send('Do this')
 
     # The error should still get propageted in the 'worker'
     with pytest.raises(RuntimeError):
         with thread_task_queue.next_task(timeout=WAIT_TIMEOUT) as task:
-            async with task.processing():
+            with task.processing():
                 raise RuntimeError('Cannea do it captain!')
 
     # And the task sender should get a remote exception to inform them of the problem

--- a/test/rmq/test_tasks.py
+++ b/test/rmq/test_tasks.py
@@ -251,7 +251,7 @@ async def test_queue_iter_not_process(task_queue: rmq.RmqTaskQueue):
 async def test_queue_task_forget(task_queue: rmq.RmqTaskQueue):
     """
     Check what happens when we forget to process a task we said we would
-    WARNING: This test mail fail when running with a debugger as it relies on the 'outcome'
+    WARNING: This test may fail when running with a debugger as it relies on the 'outcome'
     reference count dropping to zero but the debugger may be preventing this.
     """
     outcomes = [await task_queue.task_send(1)]


### PR DESCRIPTION
The release of kiwipy v0.8.0 made some breaking changes to the intended API of RmqThreadCommunicator.  I'm putting back tests that check for the intended API which will be fixed in due time.