### PR TITLE
Dependencies: Update requirement `pyyaml~=6.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = ['ommunication', 'messaging', 'rpc', 'broadcast']
 requires-python = '>=3.7'
 dependencies = [
     'deprecation',
-    'pyyaml~=5.4',
+    'pyyaml~=6.0',
     'shortuuid',
 ]
 


### PR DESCRIPTION
This latest version adds official support for Python 3.11.