### PR TITLE
`aiormq==6.8.1` that is pinned in aiida-core requires `pamqp==3.3.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ pre-commit = [
 ]
 rmq = [
     'aio-pika~=9.4.0',
-    'pamqp~=3.2',
+    'pamqp~=3.3',
     'pytray>=0.3.4,<0.4.0',
 ]
 tests = [


### PR DESCRIPTION
During conda release for `v2.7.0rc0` we ran into this issue See https://github.com/conda-forge/aiida-core-feedstock/pull/106