### PR TITLE
Allow to send early replies without releasing the task slot

### DIFF
--- a/src/kiwipy/rmq/communicator.py
+++ b/src/kiwipy/rmq/communicator.py
@@ -520,10 +520,10 @@ class RmqCommunicator:
         result = await publisher.broadcast_send(body, sender, subject, correlation_id)
         return result
 
-    async def task_send(self, task, no_reply=False):
+    async def task_send(self, task, no_reply=False, nowait=False):
         try:
             task_queue = await self.get_default_task_queue()
-            result = await task_queue.task_send(task, no_reply)
+            result = await task_queue.task_send(task, no_reply, nowait)
             return result
         except aio_pika.exceptions.DeliveryError as exception:
             raise kiwipy.UnroutableError(str(exception))

--- a/src/kiwipy/rmq/tasks.py
+++ b/src/kiwipy/rmq/tasks.py
@@ -157,7 +157,8 @@ class RmqTaskSubscriber(messages.BaseConnectionWithExchange):
             for subscriber in self._subscribers.values():
                 try:
                     subscriber = utils.ensure_coroutine(subscriber)
-                    result = await subscriber(self, rmq_task.body)
+                    # Pass task object as third argument for early reply capability
+                    result = await subscriber(self, rmq_task.body, rmq_task)
 
                     # If a task returns a future it is not considered done until the chain of
                     # futures (i.e. if the first future resolves to a future and so on) finishes

--- a/src/kiwipy/rmq/tasks.py
+++ b/src/kiwipy/rmq/tasks.py
@@ -2,8 +2,9 @@
 import asyncio
 import collections
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 import logging
-from typing import Generator, Optional
+from typing import Generator, Optional, Union
 import uuid
 import weakref
 
@@ -16,9 +17,26 @@ from . import defaults, messages, utils
 
 _LOGGER = logging.getLogger(__name__)
 
-__all__ = 'RmqTaskSubscriber', 'RmqTaskPublisher', 'RmqTaskQueue', 'RmqIncomingTask'
+__all__ = 'RmqTaskSubscriber', 'RmqTaskPublisher', 'RmqTaskQueue', 'RmqIncomingTask', 'TaskResult'
 
-TaskInfo = collections.namedtuple('TaskBody', ('task', 'no_reply'))
+TaskInfo = collections.namedtuple('TaskBody', ('task', 'no_reply', 'nowait'))
+
+
+@dataclass
+class TaskResult:
+    """Result from a task subscriber with immediate ID and deferred result.
+
+    This is used when a subscriber wants to:
+    1. Return an immediate identifier (task_id) that can be sent to the client right away
+    2. Provide a Future that kiwipy will wait on before acknowledging the message
+
+    The reply behavior depends on the `nowait` flag in the task message:
+    - nowait=True: Send {task_id, result: None} immediately, ack when Future done
+    - nowait=False: Wait for Future, send {task_id, result: <resolved>}, then ack
+    """
+
+    task_id: Union[int, str, uuid.UUID]
+    result: kiwipy.Future  # Future resolves to Any, used for reply content
 
 
 class RmqTaskSubscriber(messages.BaseConnectionWithExchange):
@@ -153,34 +171,146 @@ class RmqTaskSubscriber(messages.BaseConnectionWithExchange):
         """
         # Decode the message tuple into a task body for easier use
         rmq_task = RmqIncomingTask(self, message)
-        async with rmq_task.processing() as outcome:
-            for subscriber in self._subscribers.values():
-                try:
-                    subscriber = utils.ensure_coroutine(subscriber)
-                    # Pass task object as third argument for early reply capability
-                    result = await subscriber(self, rmq_task.body, rmq_task)
+        outcome = rmq_task.process()  # Returns Future with done callback for ack
 
-                    # If a task returns a future it is not considered done until the chain of
-                    # futures (i.e. if the first future resolves to a future and so on) finishes
-                    # and produces a concrete result
-                    while asyncio.isfuture(result):
-                        if not rmq_task.no_reply:
-                            await self._send_response(utils.pending_response(), message)
-                        result = await result
-                except kiwipy.TaskRejected:
-                    # Task was rejected by this subscriber, keep trying
-                    continue
-                except kiwipy.CancelledError:
-                    # The subscriber has cancelled their processing of the task
-                    outcome.cancel()
-                except Exception as exc:  # pylint: disable=broad-except
-                    # There was an exception during the processing of this task
-                    outcome.set_exception(exc)
-                    _LOGGER.exception('Exception occurred while processing task.')
+        for subscriber in self._subscribers.values():
+            try:
+                subscriber = utils.ensure_coroutine(subscriber)
+                # Call subscriber with just (comm, task) - kiwipy handles TaskResult internally
+                result = await subscriber(self, rmq_task.body)
+
+                # Handle TaskResult: subscriber returns TaskResult(task_id, result=Future)
+                if isinstance(result, TaskResult):
+                    # If nowait, send task_id immediately as reply
+                    if rmq_task.nowait and not rmq_task.no_reply:
+                        # Send just the task_id for nowait mode
+                        reply_body = utils.result_response(result.task_id)
+                        await self._send_response(reply_body, message)
+                        rmq_task._early_reply_sent = True
+
+                    # Attach callback to wait for result Future and ack when done
+                    self._attach_task_result_callback(result, outcome, rmq_task)
+                    return
+
+                # If a task returns a future, attach a done callback instead of awaiting.
+                # This keeps the task slot blocked (message unacked) until the future resolves.
+                if asyncio.isfuture(result):
+                    if not rmq_task.no_reply:
+                        await self._send_response(utils.pending_response(), message)
+                    self._attach_outcome_callback(result, outcome, rmq_task)
+                    return  # Don't block - ack happens when result future resolves
+
+                # Non-future result: complete immediately
+                outcome.set_result(result)
+                return  # Got handled
+
+            except kiwipy.TaskRejected:
+                # Task was rejected by this subscriber, keep trying
+                continue
+            except kiwipy.CancelledError:
+                # The subscriber has cancelled their processing of the task
+                outcome.cancel()
+                return
+            except Exception as exc:  # pylint: disable=broad-except
+                # There was an exception during the processing of this task
+                outcome.set_exception(exc)
+                _LOGGER.exception('Exception occurred while processing task.')
+                return
+
+    def _attach_outcome_callback(
+        self, result_future: asyncio.Future, outcome: asyncio.Future, rmq_task: 'RmqIncomingTask' = None
+    ):
+        """Attach a callback to resolve the outcome when the result future completes.
+
+        This keeps the task slot blocked (message unacked) until the future resolves.
+        Handles chained futures (futures that resolve to futures) using a while loop.
+        Also handles TaskResult by extracting the result Future and waiting for it.
+        """
+
+        def resolve_chain(fut: asyncio.Future):
+            if fut.cancelled():
+                outcome.cancel()
+                return
+            if fut.exception():
+                outcome.set_exception(fut.exception())
+                return
+
+            result = fut.result()
+
+            # Follow chain of futures with a while loop
+            while asyncio.isfuture(result):
+                if result.done():
+                    # Already resolved - get result and continue loop
+                    if result.cancelled():
+                        outcome.cancel()
+                        return
+                    if result.exception():
+                        outcome.set_exception(result.exception())
+                        return
+                    result = result.result()
                 else:
-                    # All good
-                    outcome.set_result(result)
-                    break  # Got handled
+                    # Not done yet - attach callback and return
+                    result.add_done_callback(resolve_chain)
+                    return
+
+            # Check if the result is a TaskResult - need to handle it specially
+            if isinstance(result, TaskResult):
+                # If nowait, send task_id immediately as early reply (if not already sent)
+                if rmq_task and rmq_task.nowait and not rmq_task.no_reply and not rmq_task.early_reply_sent:
+                    # Need to send early reply - schedule it in the event loop
+                    async def send_early_reply():
+                        reply_body = utils.result_response(result.task_id)
+                        await self._send_response(reply_body, rmq_task._message)
+                        rmq_task._early_reply_sent = True
+                    self.loop().create_task(send_early_reply())
+                self._attach_task_result_callback(result, outcome, rmq_task)
+                return
+
+            outcome.set_result(result)
+
+        result_future.add_done_callback(resolve_chain)
+
+    def _attach_task_result_callback(
+        self, task_result: TaskResult, outcome: asyncio.Future, rmq_task: 'RmqIncomingTask'
+    ):
+        """Attach a callback to handle TaskResult when the result Future completes.
+
+        This keeps the task slot blocked (message unacked) until the Future resolves.
+        - If nowait=True: Early reply with task_id was already sent, just ack when done
+        - If nowait=False: Send the full result when done
+
+        Note: task_result.result is a kiwipy.Future (concurrent.futures.Future) which may be
+        completed from a different thread. We use call_soon_threadsafe to safely update the
+        asyncio.Future outcome from the callback.
+        """
+        loop = self.loop()
+        nowait = rmq_task.nowait if rmq_task else False
+
+        def on_result_done(fut):
+            # This callback may be called from a different thread (plumpy's event loop)
+            # Use call_soon_threadsafe to safely update the asyncio outcome Future
+            if fut.cancelled():
+                loop.call_soon_threadsafe(outcome.cancel)
+                return
+
+            try:
+                exc = fut.exception()
+            except Exception:
+                exc = None
+            if exc is not None:
+                loop.call_soon_threadsafe(outcome.set_exception, exc)
+                return
+
+            resolved_result = fut.result()
+
+            if nowait:
+                # Early reply with task_id was already sent, just ack (outcome not used for reply)
+                loop.call_soon_threadsafe(outcome.set_result, resolved_result)
+            else:
+                # Send the full result - for backward compatibility, just the resolved result
+                loop.call_soon_threadsafe(outcome.set_result, resolved_result)
+
+        task_result.result.add_done_callback(on_result_done)
 
     def _build_response_message(self, body, incoming_message):
         """
@@ -228,6 +358,10 @@ class RmqIncomingTask:
     @property
     def no_reply(self) -> bool:
         return self._task_info.no_reply
+
+    @property
+    def nowait(self) -> bool:
+        return self._task_info.nowait
 
     @property
     def state(self) -> str:
@@ -376,24 +510,26 @@ class RmqTaskPublisher(messages.BasePublisherWithReplyQueue):
         )
         self._task_queue_name = queue_name
 
-    async def task_send(self, task, no_reply: bool = False) -> asyncio.Future:
+    async def task_send(self, task, no_reply: bool = False, nowait: bool = False) -> asyncio.Future:
         """Send a task for processing by a task subscriber.
 
         All task messages will be set to be persistent by setting `delivery_mode=2`.
 
         :param task: The task payload
         :param no_reply: Don't send a reply containing the result of the task
+        :param nowait: If True, send task_id reply immediately instead of waiting for result
         :return: A future representing the result of the task
         """
         _LOGGER.debug(
-            'Sending task with routing key %r to RMQ queue %r (reply=%r): %r',
+            'Sending task with routing key %r to RMQ queue %r (reply=%r, nowait=%r): %r',
             self._task_queue_name,
             self._reply_queue.name,
             not no_reply,
+            nowait,
             task,
         )
         # Build the full message body and encode as a tuple
-        body = self._encode((task, no_reply))
+        body = self._encode((task, no_reply, nowait))
         # Now build up the full aio_pika message
         task_msg = aio_pika.Message(
             body=body,
@@ -458,9 +594,9 @@ class RmqTaskQueue:
         async for task in self._subscriber:
             yield task
 
-    async def task_send(self, task, no_reply: bool = False):
+    async def task_send(self, task, no_reply: bool = False, nowait: bool = False):
         """Send a task to the queue"""
-        return await self._publisher.task_send(task, no_reply)
+        return await self._publisher.task_send(task, no_reply, nowait)
 
     async def add_task_subscriber(self, subscriber, identifier=None):
         return await self._subscriber.add_task_subscriber(subscriber, identifier)

--- a/src/kiwipy/rmq/tasks.py
+++ b/src/kiwipy/rmq/tasks.py
@@ -218,6 +218,7 @@ class RmqIncomingTask:
         self._state = TASK_PENDING
         self._outcome_ref = None  # type: Optional[weakref.ReferenceType]
         self._loop = self._subscriber.loop()
+        self._early_reply_sent = False
 
     @property
     def body(self) -> str:
@@ -230,6 +231,30 @@ class RmqIncomingTask:
     @property
     def state(self) -> str:
         return self._state
+
+    @property
+    def early_reply_sent(self) -> bool:
+        """Return True if an early reply has already been sent."""
+        return self._early_reply_sent
+
+    async def send_early_response(self, result) -> bool:
+        """Send a response without acknowledging the message.
+
+        This allows confirming receipt/progress while keeping the task slot blocked.
+        The message will be acknowledged when the task handler completes.
+
+        :param result: The result to send as the response
+        :return: True if response was sent, False if no_reply is set or already sent
+        """
+        if self.no_reply:
+            return False
+        if self._early_reply_sent:
+            return False
+
+        reply_body = utils.result_response(result)
+        await self._subscriber._send_response(reply_body, self._message)
+        self._early_reply_sent = True
+        return True
 
     def process(self) -> asyncio.Future:
         if self._state != TASK_PENDING:
@@ -300,7 +325,7 @@ class RmqIncomingTask:
             except Exception as exc:  # pylint: disable=broad-except
                 reply_body = utils.exception_response(exc)
 
-            if not self.no_reply:
+            if not self.no_reply and not self._early_reply_sent:
                 # Schedule a task to send the appropriate response
                 # pylint: disable=protected-access
                 await self._subscriber._send_response(reply_body, self._message)

--- a/src/kiwipy/rmq/threadcomms.py
+++ b/src/kiwipy/rmq/threadcomms.py
@@ -212,9 +212,9 @@ class RmqThreadCommunicator(kiwipy.Communicator):
         self._ensure_open()
         return self._loop_scheduler.await_(self._communicator.remove_broadcast_subscriber(identifier))
 
-    def task_send(self, task, no_reply=False):
+    def task_send(self, task, no_reply=False, nowait=False):
         self._ensure_open()
-        return self._loop_scheduler.await_(self._communicator.task_send(task, no_reply))
+        return self._loop_scheduler.await_(self._communicator.task_send(task, no_reply, nowait))
 
     def task_queue(
         self, queue_name: str, prefetch_size=defaults.TASK_PREFETCH_SIZE, prefetch_count=defaults.TASK_PREFETCH_COUNT
@@ -287,8 +287,8 @@ class RmqThreadTaskQueue:
         for task in self._loop_scheduler.async_iter(self._task_queue):
             yield RmqThreadIncomingTask(task, self._loop_scheduler)
 
-    def task_send(self, task, no_reply=False):
-        return self._loop_scheduler.await_(self._task_queue.task_send(task, no_reply))
+    def task_send(self, task, no_reply=False, nowait=False):
+        return self._loop_scheduler.await_(self._task_queue.task_send(task, no_reply, nowait))
 
     def add_task_subscriber(self, subscriber):
         return self._loop_scheduler.await_(self._task_queue.add_task_subscriber(self._wrap_subscriber(subscriber)))

--- a/test/rmq/test_tasks.py
+++ b/test/rmq/test_tasks.py
@@ -53,7 +53,7 @@ async def test_task_send(communicator: kiwipy.rmq.RmqCommunicator):
 
     tasks = []
 
-    def on_task(_comm, task, _incoming_task):
+    def on_task(_comm, task):
         tasks.append(task)
         return RESULT
 
@@ -77,7 +77,7 @@ async def test_future_task(communicator: kiwipy.rmq.RmqCommunicator):
 
     tasks = []
 
-    def on_task(_comm, task, _incoming_task):
+    def on_task(_comm, task):
         tasks.append(task)
         return result_future
 
@@ -104,7 +104,7 @@ async def test_task_exception(communicator: kiwipy.rmq.RmqCommunicator):
 
     tasks = []
 
-    def on_task(_comm, task, _incoming_task):
+    def on_task(_comm, task):
         tasks.append(task)
         raise RuntimeError('I cannea do it Captain!')
 
@@ -127,7 +127,7 @@ async def test_task_no_reply(communicator: kiwipy.rmq.RmqCommunicator):
 
     task_future = asyncio.Future()
 
-    def on_task(_comm, task, _incoming_task):
+    def on_task(_comm, task):
         tasks.append(task)
         task_future.set_result(RESULT)
         return RESULT
@@ -154,7 +154,7 @@ async def test_custom_tasks_queue(communicator: kiwipy.rmq.RmqCommunicator):
 
     task_future = asyncio.Future()
 
-    def on_task(_comm, task, _incoming_task):
+    def on_task(_comm, task):
         tasks.append(task)
         task_future.set_result(RESULT)
         return RESULT

--- a/test/rmq/test_tasks.py
+++ b/test/rmq/test_tasks.py
@@ -305,3 +305,49 @@ async def test_task_processing_exception(task_queue: rmq.RmqTaskQueue):
     with pytest.raises(kiwipy.QueueEmpty):
         async with task_queue.next_task(timeout=1.):
             pass
+
+
+@unittest.skipIf(not aio_pika, 'Requires aio_pika library and RabbitMQ')
+@pytest.mark.asyncio
+async def test_early_reply(task_queue: rmq.RmqTaskQueue):
+    """Test that we can send an early reply without acknowledging the message.
+
+    This allows the client to receive confirmation that work has started
+    while the task slot remains blocked until the work completes.
+    """
+    task_future = await task_queue.task_send('Do this')
+
+    async with task_queue.next_task() as task:
+        # Send early reply to confirm receipt
+        sent = await task.send_early_response('started')
+        assert sent is True
+        assert task.early_reply_sent is True
+
+        # Sending again should return False
+        sent_again = await task.send_early_response('started again')
+        assert sent_again is False
+
+        # Complete the task
+        async with task.processing() as outcome:
+            outcome.set_result('completed')
+
+    # The client should receive the early reply ('started'), not the final result
+    result = await task_future
+    assert result == 'started'
+
+
+@unittest.skipIf(not aio_pika, 'Requires aio_pika library and RabbitMQ')
+@pytest.mark.asyncio
+async def test_early_reply_no_reply_mode(task_queue: rmq.RmqTaskQueue):
+    """Test that early reply does nothing when no_reply is set."""
+    # Send with no_reply=True
+    await task_queue.task_send('Do this', no_reply=True)
+
+    async with task_queue.next_task() as task:
+        # Early reply should return False when no_reply is set
+        sent = await task.send_early_response('started')
+        assert sent is False
+        assert task.early_reply_sent is False
+
+        async with task.processing() as outcome:
+            outcome.set_result('done')

--- a/test/rmq/test_tasks.py
+++ b/test/rmq/test_tasks.py
@@ -53,7 +53,7 @@ async def test_task_send(communicator: kiwipy.rmq.RmqCommunicator):
 
     tasks = []
 
-    def on_task(_comm, task):
+    def on_task(_comm, task, _incoming_task):
         tasks.append(task)
         return RESULT
 
@@ -77,7 +77,7 @@ async def test_future_task(communicator: kiwipy.rmq.RmqCommunicator):
 
     tasks = []
 
-    def on_task(_comm, task):
+    def on_task(_comm, task, _incoming_task):
         tasks.append(task)
         return result_future
 
@@ -104,7 +104,7 @@ async def test_task_exception(communicator: kiwipy.rmq.RmqCommunicator):
 
     tasks = []
 
-    def on_task(_comm, task):
+    def on_task(_comm, task, _incoming_task):
         tasks.append(task)
         raise RuntimeError('I cannea do it Captain!')
 
@@ -127,7 +127,7 @@ async def test_task_no_reply(communicator: kiwipy.rmq.RmqCommunicator):
 
     task_future = asyncio.Future()
 
-    def on_task(_comm, task):
+    def on_task(_comm, task, _incoming_task):
         tasks.append(task)
         task_future.set_result(RESULT)
         return RESULT
@@ -154,7 +154,7 @@ async def test_custom_tasks_queue(communicator: kiwipy.rmq.RmqCommunicator):
 
     task_future = asyncio.Future()
 
-    def on_task(_comm, task):
+    def on_task(_comm, task, _incoming_task):
         tasks.append(task)
         task_future.set_result(RESULT)
         return RESULT

--- a/test/utils.py
+++ b/test/utils.py
@@ -196,7 +196,7 @@ class CommunicatorTester(metaclass=abc.ABCMeta):
 
         tasks = []
 
-        def on_task(_com, task):
+        def on_task(_comm, task):
             tasks.append(task)
             raise EXCEPTION
 


### PR DESCRIPTION
The logic for the early response feature is explained in the TaskResult. Instead of a future we return a TaskResult that has result

```
Result from a task subscriber with immediate ID and deferred result.

This is used when a subscriber wants to:
1. Return an immediate identifier (task_id) that can be sent to the client right away
2. Provide a Future that kiwipy will wait on before acknowledging the message

The reply behavior depends on the `nowait` flag in the task message:
- nowait=True: Send {task_id, result: None} immediately, ack when Future done
- nowait=False: Wait for Future, send {task_id, result: <resolved>}, then ack
 ```